### PR TITLE
Configuring the Output Directory

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -35,6 +35,12 @@
                         "Export PDFs when you save a file.",
                         "Export PDFs as you type in a file."
                     ]
+                },
+                "typst-lsp.outDir": {
+                    "title": "Output Directory",
+                    "description": "The directory where to export PDFs. Relative to workspace. Starting with %SOURCE_DIR% refers to the directory containing the current file",
+                    "type": "string",
+                    "default": "%SOURCE_DIR%"
                 }
             }
         },

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,4 +14,5 @@ impl Default for ExportPdfMode {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Config {
     pub export_pdf: ExportPdfMode,
+    pub out_dir: String,
 }


### PR DESCRIPTION
Allows saving files to other directories (relative to the workspace root) by setting a VSCode setting.

When started with `%SOURCE_DIR%`, it refers to the directory containing the current file. That is the default value, preserving the current behavior. That is the cleanest and most extensible method I've thought of so far. If anyone has a better system, I can update this.