### PR TITLE
Fix panic error when unwrapping root_uri without workspace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,9 @@ impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         let mut world = self.world.write().await;
         // Check if a folder is opened, if yes, use it as the root path
-        let root_path = if let Some(root) = params.root_uri {
-            root.to_file_path().unwrap()
-        } else {
-            PathBuf::new()
+        let root_path = match params.root_uri {
+            Some(root) => root.to_file_path().unwrap(),
+            None => PathBuf::new()
         };
         *world = Some(SystemWorld::new(root_path));
         

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,10 +39,10 @@ impl LanguageServer for Backend {
         // Check if a folder is opened, if yes, use it as the root path
         let root_path = match params.root_uri {
             Some(root) => root.to_file_path().unwrap(),
-            None => PathBuf::new()
+            None => PathBuf::new(),
         };
         *world = Some(SystemWorld::new(root_path));
-        
+
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 signature_help_provider: Some(SignatureHelpOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use regex::{Captures, Regex};
@@ -36,10 +36,14 @@ struct Backend {
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         let mut world = self.world.write().await;
-        *world = Some(SystemWorld::new(
-            params.root_uri.unwrap().to_file_path().unwrap(),
-        ));
-
+        // Check if a folder is opened, if yes, use it as the root path
+        let root_path = if let Some(root) = params.root_uri {
+            root.to_file_path().unwrap()
+        } else {
+            PathBuf::new()
+        };
+        *world = Some(SystemWorld::new(root_path));
+        
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 signature_help_provider: Some(SignatureHelpOptions {


### PR DESCRIPTION

Fix the following error when opening a singe file (with no folder in the workspace)
```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/main.rs:26:29
```

fixes #41 
fixes #36 