### PR TITLE
Add manual PDF creation command

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,10 @@
-**
-!addons/
+.git/**
+.github/**
+.vscode/**
+assets/**
+src/**
+target/**
+*.toml
+*.txt
+*.lock
+*.md

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -69,7 +69,8 @@
         ]
     },
     "activationEvents": [
-        "onLanguage:typst"
+        "onLanguage:typst",
+        "onCommand:typst-lsp.exportPdf"
     ],
     "scripts": {
         "build-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --target=node16",

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -63,14 +63,14 @@
         ],
         "commands": [
             {
-                "command": "typst-lsp.exportPdf",
-                "title": "Export current file as PDF"
+                "command": "typst-lsp.exportCurrentPdf",
+                "title": "Export the currently open file as PDF"
             }
         ],
         "menus": {
             "commandPalette": [
                 {
-                    "command": "typst-lsp.exportPdf",
+                    "command": "typst-lsp.exportCurrentPdf",
                     "when": "editorLangId == typst"
                 }
             ]
@@ -78,7 +78,7 @@
     },
     "activationEvents": [
         "onLanguage:typst",
-        "onCommand:typst-lsp.exportPdf"
+        "onCommand:typst-lsp.exportCurrentPdf"
     ],
     "scripts": {
         "build-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --target=node16",

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -66,7 +66,15 @@
                 "command": "typst-lsp.exportPdf",
                 "title": "Export current file as PDF"
             }
-        ]
+        ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "typst-lsp.exportPdf",
+                    "when": "editorLangId == typst"
+                }
+            ]
+        }
     },
     "activationEvents": [
         "onLanguage:typst",

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -60,6 +60,12 @@
                 "scopeName": "source.typst",
                 "path": "./typst.tmLanguage.json"
             }
+        ],
+        "commands": [
+            {
+                "command": "typst.exportPdf",
+                "title": "Export current file as PDF"
+            }
         ]
     },
     "activationEvents": [

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -63,7 +63,7 @@
         ],
         "commands": [
             {
-                "command": "typst.exportPdf",
+                "command": "typst-lsp.exportPdf",
                 "title": "Export current file as PDF"
             }
         ]

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -72,5 +72,8 @@ async function commandExportCurrentPdf(): Promise<void> {
 
     const uri = activeEditor.document.uri.toString();
 
-    await client?.sendRequest('workspace/executeCommand', { command: 'typst-lsp.doPdfExport', arguments: [uri] });
+    await client?.sendRequest("workspace/executeCommand", {
+        command: "typst-lsp.doPdfExport",
+        arguments: [uri],
+    });
 }

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -1,4 +1,4 @@
-import { type ExtensionContext, workspace } from "vscode";
+import { type ExtensionContext, workspace, window, commands } from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 
@@ -11,7 +11,7 @@ import {
 
 let client: LanguageClient | undefined = undefined;
 
-export function activate(_context: ExtensionContext): Promise<void> {
+export function activate(context: ExtensionContext): Promise<void> {
     const serverCommand = getServer();
     const serverOptions: ServerOptions = {
         run: { command: serverCommand },
@@ -29,6 +29,8 @@ export function activate(_context: ExtensionContext): Promise<void> {
             settings: workspace.getConfiguration("typst-lsp"),
         });
     }, null);
+
+    context.subscriptions.push(commands.registerCommand("typst-lsp.exportPdf", commandExportPdf));
 
     return client.start();
 }
@@ -58,4 +60,12 @@ function fileExists(path: string): boolean {
     } catch (error) {
         return false;
     }
+}
+
+async function commandExportPdf() {
+    const activeEditor = window.activeTextEditor;
+    if (!activeEditor) {
+        return;
+    }
+    await commands.executeCommand("typst.exportPdf", activeEditor.document.uri);
 }

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -66,7 +66,7 @@ function fileExists(path: string): boolean {
 
 async function commandExportCurrentPdf(): Promise<void> {
     const activeEditor = window.activeTextEditor;
-    if (activeEditor == null) {
+    if (!activeEditor) {
         return;
     }
 

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -66,7 +66,7 @@ function fileExists(path: string): boolean {
 
 async function commandExportCurrentPdf(): Promise<void> {
     const activeEditor = window.activeTextEditor;
-    if (!activeEditor) {
+    if (activeEditor === undefined) {
         return;
     }
 

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -30,7 +30,9 @@ export function activate(context: ExtensionContext): Promise<void> {
         });
     }, null);
 
-    context.subscriptions.push(commands.registerCommand("typst-lsp.exportPdf", commandExportPdf));
+    context.subscriptions.push(
+        commands.registerCommand("typst-lsp.exportCurrentPdf", commandExportCurrentPdf)
+    );
 
     return client.start();
 }
@@ -62,10 +64,10 @@ function fileExists(path: string): boolean {
     }
 }
 
-async function commandExportPdf() {
+async function commandExportCurrentPdf() {
     const activeEditor = window.activeTextEditor;
     if (!activeEditor) {
         return;
     }
-    await commands.executeCommand("typst.exportPdf", activeEditor.document.uri);
+    await commands.executeCommand("typst.doPdfExport", activeEditor.document.uri);
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,37 @@
+use tower_lsp::lsp_types::Url;
+
+use crate::Backend;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LspCommand {
+    ExportPdf,
+}
+
+impl From<LspCommand> for String {
+    fn from(command: LspCommand) -> Self {
+        match command {
+            LspCommand::ExportPdf => "typst.exportPdf".to_string(),
+        }
+    }
+}
+
+impl LspCommand {
+    pub fn parse(command: &str) -> Option<Self> {
+        match command {
+            "typst.exportPdf" => Some(Self::ExportPdf),
+            _ => None,
+        }
+    }
+
+    pub fn all_as_string() -> Vec<String> {
+        vec![Self::ExportPdf.into()]
+    }
+}
+
+/// Here are implemented the handlers for each command.
+impl Backend {
+    /// Export the current document as a PDF file. The client is reponsible for passing the correct file URI.
+    pub async fn command_export_pdf(&self, file: Url, text: String) {
+        self.compile_diags_export(file, text, true).await;
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -16,7 +16,7 @@ pub enum LspCommand {
 impl From<LspCommand> for String {
     fn from(command: LspCommand) -> Self {
         match command {
-            LspCommand::ExportPdf => "typst.exportPdf".to_string(),
+            LspCommand::ExportPdf => "typst-lsp.exportPdf".to_string(),
         }
     }
 }
@@ -24,7 +24,7 @@ impl From<LspCommand> for String {
 impl LspCommand {
     pub fn parse(command: &str) -> Option<Self> {
         match command {
-            "typst.exportPdf" => Some(Self::ExportPdf),
+            "typst-lsp.exportPdf" => Some(Self::ExportPdf),
             _ => None,
         }
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,10 @@
-use tower_lsp::lsp_types::Url;
+use std::fs;
+
+use serde_json::Value;
+use tower_lsp::{
+    jsonrpc::{Error, Result},
+    lsp_types::Url,
+};
 
 use crate::Backend;
 
@@ -31,7 +37,24 @@ impl LspCommand {
 /// Here are implemented the handlers for each command.
 impl Backend {
     /// Export the current document as a PDF file. The client is reponsible for passing the correct file URI.
-    pub async fn command_export_pdf(&self, file: Url, text: String) {
-        self.compile_diags_export(file, text, true).await;
+    pub async fn command_export_pdf(&self, arguments: Vec<Value>) -> Result<()> {
+        if arguments.is_empty() {
+            return Err(Error::invalid_params("Missing file URI argument"));
+        }
+        let Some(file_uri) = arguments.first().and_then(|v| v.as_str()) else {
+            return Err(Error::invalid_params(
+                "Missing file URI as first argument",
+            ));
+        };
+        let file_uri = Url::parse(file_uri)
+            .map_err(|_| Error::invalid_params("Parameter is not a valid URI"))?;
+        let text = fs::read_to_string(
+            file_uri
+                .to_file_path()
+                .map_err(|_| Error::invalid_params("Could not convert file URI to path"))?,
+        )
+        .map_err(|_| Error::internal_error())?;
+        self.compile_diags_export(file_uri, text, true).await;
+        Ok(())
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -16,7 +16,7 @@ pub enum LspCommand {
 impl From<LspCommand> for String {
     fn from(command: LspCommand) -> Self {
         match command {
-            LspCommand::ExportPdf => "typst-lsp.exportPdf".to_string(),
+            LspCommand::ExportPdf => "typst-lsp.doPdfExport".to_string(),
         }
     }
 }
@@ -24,7 +24,7 @@ impl From<LspCommand> for String {
 impl LspCommand {
     pub fn parse(command: &str) -> Option<Self> {
         match command {
-            "typst-lsp.exportPdf" => Some(Self::ExportPdf),
+            "typst-lsp.doPdfExport" => Some(Self::ExportPdf),
             _ => None,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ impl LanguageServer for Backend {
                         work_done_progress: None,
                     },
                 }),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
                 completion_provider: Some(CompletionOptions {
                     trigger_characters: Some(vec![
                         String::from("#"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,7 @@ impl LanguageServer for Backend {
             arguments,
             work_done_progress_params: _,
         } = params;
+        self.client.log_message(MessageType::INFO, &command).await;
         match LspCommand::parse(&command) {
             Some(LspCommand::ExportPdf) => {
                 self.command_export_pdf(arguments).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,22 +121,7 @@ impl LanguageServer for Backend {
         } = params;
         match LspCommand::parse(&command) {
             Some(LspCommand::ExportPdf) => {
-                if arguments.is_empty() {
-                    return Err(Error::invalid_params("Missing file URI argument"));
-                }
-                let Some(file_uri) = arguments.first().and_then(|v| v.as_str()) else {
-                    return Err(Error::invalid_params(
-                        "Missing file URI as first argument",
-                    ));
-                };
-                let file_uri = Url::parse(file_uri)
-                    .map_err(|_| Error::invalid_params("Parameter is not a valid URI"))?;
-                let text =
-                    fs::read_to_string(file_uri.to_file_path().map_err(|_| {
-                        Error::invalid_params("Could not convert file URI to path")
-                    })?)
-                    .map_err(|_| Error::internal_error())?;
-                self.command_export_pdf(file_uri, text).await;
+                self.command_export_pdf(arguments).await?;
             }
             None => {
                 return Err(Error::method_not_found());


### PR DESCRIPTION
This command is available through the command panel in the IDE and allows to manual trigger the compilation of the active editor (if and only if it's a Typst file).

This will be particularly useful for people that set the automatic compilation setting to `never`.

Closes https://github.com/nvarner/typst-lsp/issues/42