### PR TITLE
ci: more fixes for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
 
     name: build (${{ matrix.platform }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
+    env:
+      target: ${{ matrix.platform }}-${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
@@ -56,7 +58,6 @@ jobs:
           node-version: 16
       - run: npm install
         working-directory: ./addons/vscode
-
       - name: rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -67,10 +68,8 @@ jobs:
       - name: Install ARM target toolchain
         if: matrix.rust-target == 'arm-unknown-linux-gnueabihf'
         run: sudo apt-get install gcc-arm-linux-gnueabihf
-
       - shell: pwsh
         run: |
-          echo "target=${{ matrix.platform }}-${{ matrix.arch }}" >> $env:GITHUB_ENV
           cargo build --release -p typst-lsp --target ${{ matrix.rust-target }}
           mkdir -p addons/vscode/out
           cp "target/${{ matrix.rust-target }}/release/typst-lsp$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "addons/vscode/out/"
@@ -95,9 +94,9 @@ jobs:
       volumes:
         - /usr/local/cargo/registry:/usr/local/cargo/registry
     env:
+      target: alpine-x64
       RUST_TARGET: x86_64-unknown-linux-musl
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
-
     steps:
       - name: Install dependencies
         run: apk add --no-cache git clang lld musl-dev nodejs npm
@@ -105,7 +104,6 @@ jobs:
         uses: actions/checkout@v3
       - name: build server binary
         run: |
-          echo "target=alpine-x64" >> $env:GITHUB_ENV
           cargo build --release -p typst-lsp --target $RUST_TARGET
           mkdir -p addons/vscode/out
           cp "target/$RUST_TARGET/release/typst-lsp" "addons/vscode/out/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           cargo build --release -p typst-lsp --target ${{ matrix.rust-target }}
           mkdir -p addons/vscode/out
           cp "target/${{ matrix.rust-target }}/release/typst-lsp$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "addons/vscode/out/"
-          cp "target/${{ matrix.rust-target }}/release/typst-lsp$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "typst-lsp-${{ matrix.platform }}-${{ matrix.arch }}$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )"
+          cp "target/${{ matrix.rust-target }}/release/typst-lsp$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "typst-lsp-${{ env.target }}$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )"
       - shell: pwsh
         run: npm run package -- --target ${{ env.target }} -o typst-lsp-${{ env.target }}.vsix
         working-directory: ./addons/vscode
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: typst-lsp-${{ env.target }}
-          path: typst-lsp-${{ matrix.platform }}-${{ matrix.arch }}${{ fromJSON('["", ".exe"]')[matrix.platform == 'win32'] }}
+          path: typst-lsp-${{ env.target }}${{ fromJSON('["", ".exe"]')[matrix.platform == 'win32'] }}
 
   build_alpine:
     name: build (x86_64-unknown-linux-musl)


### PR DESCRIPTION
Trying to fix the new error in the alpine release job. It seems the environment variable `target` was not set properly.
Switching to the `env` key in the yaml instead of printing to `$env:GITHUB_ENV` which I suspect doesn't persist across steps.