### PR TITLE
feat: add configuration `serverPath`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 /addons/vscode/out/
 node_modules/
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /addons/vscode/out/
 node_modules/
+.vscode/

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -35,6 +35,15 @@
                         "Export PDFs when you save a file.",
                         "Export PDFs as you type in a file."
                     ]
+                },
+                "typst-lsp.serverPath": {
+                    "title": "Path to server executable",
+                    "description": "The extension can use a local typst-lsp executable instead of the one bundled with the extension. This setting controls the path to the executable.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
                 }
             }
         },


### PR DESCRIPTION
This PR adds a new conguration item `serverPath` to override the default bundled server. Closing #55.