### PR TITLE
Add Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683286087,
+        "narHash": "sha256-xseOd7W7xwF5GOF2RW8qhjmVGrKoBz+caBlreaNzoeI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3e313808bd2e0a0669430787fb22e43b2f4bf8bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,76 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    inherit
+      (builtins)
+      substring
+      ;
+    inherit
+      (nixpkgs.lib)
+      genAttrs
+      optionals
+      ;
+
+    eachSystem = f:
+      genAttrs
+      [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ]
+      (system: f nixpkgs.legacyPackages.${system});
+
+    rev = fallback:
+      if self ? rev
+      then substring 0 8 self.rev
+      else fallback;
+
+    packageFor = pkgs:
+      pkgs.rustPlatform.buildRustPackage {
+        pname = "typst-lsp";
+        version = rev "00000000";
+
+        src = self;
+
+        cargoLock = {
+          lockFile = ./Cargo.lock;
+          allowBuiltinFetchGit = true;
+        };
+
+        buildInputs = optionals pkgs.stdenv.isDarwin [
+          pkgs.darwin.apple_sdk.frameworks.CoreServices
+        ];
+      };
+  in {
+    devShells = eachSystem (pkgs: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          cargo
+          clippy
+          rust-analyzer
+          rustc
+          rustfmt
+          nodejs
+        ];
+
+        buildInputs = optionals pkgs.stdenv.isDarwin [
+          pkgs.darwin.apple_sdk.frameworks.CoreServices
+          pkgs.libiconv
+        ];
+
+        RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+      };
+    });
+
+    packages = eachSystem (pkgs: {
+      default = packageFor pkgs;
+    });
+  };
+}


### PR DESCRIPTION
This allows Nix users to install typst-lsp just by specifying the GitHub repository. Since typst-lsp isn't packaged anywhere yet that is quite useful. It also provides a development shell that includes some basic rust tools and Node.js. It's mostly based on the [flake in the typst repo](https://github.com/typst/typst/blob/main/flake.nix). I tested both the package as well as the devshell and found no issues.