### PR TITLE
Add the LSP capability for save notifications

### DIFF
--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -44,8 +44,13 @@ impl LanguageServer for TypstServer {
                     ]),
                     ..Default::default()
                 }),
-                text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                    TextDocumentSyncKind::INCREMENTAL,
+                text_document_sync: Some(TextDocumentSyncCapability::Options(
+                    TextDocumentSyncOptions {
+                        open_close: Some(true),
+                        change: Some(TextDocumentSyncKind::INCREMENTAL),
+                        save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+                        ..Default::default()
+                    },
                 )),
                 execute_command_provider: Some(ExecuteCommandOptions {
                     commands: LspCommand::all_as_string(),


### PR DESCRIPTION
Currently, auto-exporting the PDF on save doesn't work with the [Helix editor](https://github.com/helix-editor/helix). This is because in the `text_document_sync` server capability, typst-lsp doesn't include the capability for save notifications. As far as I understand, the client shouldn't send save notifications in this case(see the [documentation of TextDocumentSyncOptions in the LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didRename)). Adding the capability fixes the issue for me. I'm guessing that this isn't an issue VSCode because VSCode isn't fully spec compliant and just sends the notification anyway.

The LSP specification isn't super clear on this so if I misunderstood it, please let me know. In that case, I'll open a PR to fix this in Helix. Either way, it shouldn't hurt to explicitly set the capability though.