### PR TITLE
Implement selectionRange request

### DIFF
--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -62,6 +62,7 @@ impl LanguageServer for TypstServer {
                 }),
                 document_symbol_provider: Some(OneOf::Left(true)),
                 workspace_symbol_provider: Some(OneOf::Left(true)),
+                selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
                 ..Default::default()
             },
             ..Default::default()
@@ -352,5 +353,21 @@ impl LanguageServer for TypstServer {
                 .log_message(MessageType::ERROR, "Got invalid configuration object")
                 .await;
         }
+    }
+
+    async fn selection_range(
+        &self,
+        params: SelectionRangeParams,
+    ) -> jsonrpc::Result<Option<Vec<SelectionRange>>> {
+        let uri = &params.text_document.uri;
+        let positions = params.positions;
+
+        let (world, source_id) = self.get_world_with_main_uri(uri).await;
+        let source = world
+            .get_workspace()
+            .sources
+            .get_open_source_by_id(source_id);
+
+        Ok(self.get_selection_range(source, &positions))
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -18,6 +18,7 @@ pub mod export;
 pub mod hover;
 pub mod log;
 pub mod lsp;
+pub mod selection_range;
 pub mod signature;
 pub mod symbols;
 pub mod typst_compiler;

--- a/src/server/selection_range.rs
+++ b/src/server/selection_range.rs
@@ -1,0 +1,40 @@
+use super::TypstServer;
+use crate::{
+    config::PositionEncoding,
+    lsp_typst_boundary::{lsp_to_typst, typst_to_lsp, LspPosition},
+    workspace::source::Source,
+};
+use tower_lsp::lsp_types::SelectionRange;
+use typst::syntax::LinkedNode;
+
+fn range_for_node(
+    source: &Source,
+    position_encoding: PositionEncoding,
+    node: &LinkedNode,
+) -> SelectionRange {
+    let range = typst_to_lsp::range(node.range(), source.as_ref(), position_encoding);
+    SelectionRange {
+        range: range.raw_range,
+        parent: node
+            .parent()
+            .map(|node| Box::new(range_for_node(source, position_encoding, node))),
+    }
+}
+
+impl TypstServer {
+    pub fn get_selection_range(
+        &self,
+        source: &Source,
+        positions: &[LspPosition],
+    ) -> Option<Vec<SelectionRange>> {
+        let position_encoding = self.get_const_config().position_encoding;
+        let mut ranges = Vec::new();
+        for &position in positions {
+            let typst_offset =
+                lsp_to_typst::position_to_offset(position, position_encoding, source.as_ref());
+            let leaf = self.get_leaf(source, typst_offset)?;
+            ranges.push(range_for_node(source, position_encoding, &leaf));
+        }
+        Some(ranges)
+    }
+}


### PR DESCRIPTION
This allows [this VSCode feature](https://code.visualstudio.com/docs/editor/codebasics#_shrinkexpand-selection) to work. I think it might be particularly useful for editing math in Typst.