### PR TITLE
Fix document symbols for functions and variables

### DIFF
--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -2,14 +2,12 @@ use serde_json::Value as JsonValue;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{jsonrpc, LanguageServer};
 use typst::ide::autocomplete;
-use typst::syntax::LinkedNode;
 
 use crate::config::{ConstConfig, ExportPdfMode, PositionEncoding};
 use crate::ext::InitializeParamsExt;
 use crate::lsp_typst_boundary::{lsp_to_typst, typst_to_lsp};
 
 use super::command::LspCommand;
-use super::log::LogMessage;
 use super::TypstServer;
 
 #[tower_lsp::async_trait]
@@ -122,14 +120,14 @@ impl LanguageServer for TypstServer {
             .get_open_source_by_id(source_id);
 
         // the following is useful to debug AST stuff
-        let message = {
+        /* let message = {
             let root = LinkedNode::new(source.as_ref().root());
             LogMessage {
                 message_type: MessageType::LOG,
                 message: format!("{root:#?}"),
             }
         };
-        self.log_to_client(message).await;
+        self.log_to_client(message).await; */
 
         self.on_source_changed(&world, &config, source).await;
     }

--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -2,12 +2,14 @@ use serde_json::Value as JsonValue;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{jsonrpc, LanguageServer};
 use typst::ide::autocomplete;
+use typst::syntax::LinkedNode;
 
 use crate::config::{ConstConfig, ExportPdfMode, PositionEncoding};
 use crate::ext::InitializeParamsExt;
 use crate::lsp_typst_boundary::{lsp_to_typst, typst_to_lsp};
 
 use super::command::LspCommand;
+use super::log::LogMessage;
 use super::TypstServer;
 
 #[tower_lsp::async_trait]
@@ -120,14 +122,14 @@ impl LanguageServer for TypstServer {
             .get_open_source_by_id(source_id);
 
         // the following is useful to debug AST stuff
-        /* let message = {
+        let message = {
             let root = LinkedNode::new(source.as_ref().root());
             LogMessage {
                 message_type: MessageType::LOG,
                 message: format!("{root:#?}"),
             }
         };
-        self.log_to_client(message).await; */
+        self.log_to_client(message).await;
 
         self.on_source_changed(&world, &config, source).await;
     }

--- a/src/server/symbols.rs
+++ b/src/server/symbols.rs
@@ -81,14 +81,15 @@ fn get_ident(
                 return Ok(None);
             };
             let kind = match parent.kind() {
-                // in case we have a Destructuring pattern holding an Ident, we need to check the parent of the pattern
-                SyntaxKind::Destructuring => {
-                    let Some(parent) = parent.parent() else {
+                // for variable definitions, the Let binding holds an Ident
+                SyntaxKind::LetBinding => SymbolKind::VARIABLE,
+                // for function definitions, the Let binding holds a Closure which holds the Ident
+                SyntaxKind::Closure => {
+                    let Some(grand_parent) = parent.parent() else {
                         return Ok(None);
                     };
-                    match parent.kind() {
-                        SyntaxKind::LetBinding => SymbolKind::VARIABLE,
-                        SyntaxKind::Closure => SymbolKind::FUNCTION,
+                    match grand_parent.kind() {
+                        SyntaxKind::LetBinding => SymbolKind::FUNCTION,
                         _ => return Ok(None),
                     }
                 }


### PR DESCRIPTION
The AST structure changed in the latest version of typst apparently, so it broke document symbols for functions and variables.

This PR fixes it so variables and functions appear in the document and workspace symbols listing.