### PR TITLE
make `rootPath` configurable

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -36,6 +36,15 @@
                         "Export PDFs as you type in a file."
                     ]
                 },
+                "typst-lsp.rootPath": {
+                    "title": "Root path",
+                    "description": "Configure the root for absolute paths in typst",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
                 "typst-lsp.semanticTokens": {
                     "title": "Semantic tokens mode",
                     "description": "Enable or disable semantic tokens (LSP syntax highlighting)",

--- a/src/lsp_typst_boundary/world.rs
+++ b/src/lsp_typst_boundary/world.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use chrono::{Datelike, FixedOffset, Local, TimeZone, Timelike, Utc};
 use comemo::Prehashed;
 use tokio::sync::OwnedRwLockReadGuard;
@@ -15,11 +17,20 @@ use super::{typst_to_lsp, TypstPath, TypstSource, TypstSourceId};
 pub struct WorkspaceWorld {
     workspace: OwnedRwLockReadGuard<Workspace>,
     main: SourceId,
+    root_path: Option<PathBuf>,
 }
 
 impl WorkspaceWorld {
-    pub fn new(workspace: OwnedRwLockReadGuard<Workspace>, main: SourceId) -> Self {
-        Self { workspace, main }
+    pub fn new(
+        workspace: OwnedRwLockReadGuard<Workspace>,
+        main: SourceId,
+        root_path: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            workspace,
+            main,
+            root_path,
+        }
     }
 
     pub fn get_workspace(&self) -> &OwnedRwLockReadGuard<Workspace> {
@@ -28,6 +39,13 @@ impl WorkspaceWorld {
 }
 
 impl World for WorkspaceWorld {
+    fn root(&self) -> &Path {
+        match &self.root_path {
+            Some(path) => path.as_ref(),
+            None => Path::new(""),
+        }
+    }
+
     fn library(&self) -> &Prehashed<Library> {
         let workspace = self.get_workspace();
         &workspace.typst_stdlib

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -63,7 +63,12 @@ impl TypstServer {
     }
 
     pub async fn get_world_with_main(&self, main: SourceId) -> WorkspaceWorld {
-        WorkspaceWorld::new(Arc::clone(&self.workspace).read_owned().await, main)
+        let config = self.config.read().await;
+        WorkspaceWorld::new(
+            Arc::clone(&self.workspace).read_owned().await,
+            main,
+            config.root_path.clone(),
+        )
     }
 
     pub async fn register_workspace_files(&self, params: &InitializeParams) -> jsonrpc::Result<()> {


### PR DESCRIPTION
This PR introduces a new configuration option called `rootPath`. In the original typst application, this configuration could be set using the `--root` command-line parameter or the `TYPST_ROOT` environment variable.

Closing #98 and #120.