### PR TITLE
Syntax Highlighting Fixes

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -150,8 +150,7 @@
             },
             {
                 "id": "pol",
-                "description": "Interpolated variable",
-                "superType": "keyword"
+                "description": "Interpolated variable"
             },
             {
                 "id": "error",
@@ -239,7 +238,8 @@
                         "entity.name.label.typst"
                     ],
                     "pol": [
-                        "meta.interpolation.typst"
+                        "meta.interpolation.typst",
+                        "variable.typst"
                     ],
                     "error": [
                         "invalid.typst"

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,7 +156,6 @@ impl From<PositionEncoding> for lsp_types::PositionEncodingKind {
 #[derive(Debug)]
 pub struct ConstConfig {
     pub position_encoding: PositionEncoding,
-    pub supports_multiline_tokens: bool,
     pub supports_semantic_tokens_dynamic_registration: bool,
     pub supports_config_change_registration: bool,
 }
@@ -176,7 +175,6 @@ impl From<&InitializeParams> for ConstConfig {
     fn from(params: &InitializeParams) -> Self {
         Self {
             position_encoding: Self::choose_encoding(params),
-            supports_multiline_tokens: params.supports_multiline_tokens(),
             supports_semantic_tokens_dynamic_registration: params
                 .supports_semantic_tokens_dynamic_registration(),
             supports_config_change_registration: params.supports_config_change_registration(),

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,8 +1,5 @@
-use std::ops;
-
 use tower_lsp::lsp_types::{
-    InitializeParams, Position, PositionEncodingKind, SemanticToken,
-    SemanticTokensClientCapabilities,
+    InitializeParams, Position, PositionEncodingKind, SemanticTokensClientCapabilities,
 };
 use typst::util::StrExt as TypstStrExt;
 
@@ -13,7 +10,6 @@ pub trait InitializeParamsExt {
     fn supports_config_change_registration(&self) -> bool;
     fn semantic_tokens_capabilities(&self) -> Option<&SemanticTokensClientCapabilities>;
     fn supports_semantic_tokens_dynamic_registration(&self) -> bool;
-    fn supports_multiline_tokens(&self) -> bool;
 }
 
 static DEFAULT_ENCODING: [PositionEncodingKind; 1] = [PositionEncodingKind::UTF16];
@@ -49,12 +45,6 @@ impl InitializeParamsExt for InitializeParams {
             .and_then(|semantic_tokens| semantic_tokens.dynamic_registration)
             .unwrap_or(false)
     }
-
-    fn supports_multiline_tokens(&self) -> bool {
-        self.semantic_tokens_capabilities()
-            .and_then(|semantic_tokens| semantic_tokens.multiline_token_support)
-            .unwrap_or(false)
-    }
 }
 
 pub trait StrExt {
@@ -72,7 +62,6 @@ impl StrExt for str {
 
 pub trait PositionExt {
     fn delta(&self, to: &Self) -> PositionDelta;
-    fn advance_lines(&self, lines: usize) -> Self;
 }
 
 impl PositionExt for Position {
@@ -92,92 +81,10 @@ impl PositionExt for Position {
             delta_start: char_delta,
         }
     }
-
-    fn advance_lines(&self, lines: usize) -> Self {
-        let character = if lines == 0 { self.character } else { 0 };
-        let line = self.line + lines as u32;
-        Self { line, character }
-    }
 }
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default)]
 pub struct PositionDelta {
     pub delta_line: u32,
     pub delta_start: u32,
-}
-
-impl PositionDelta {
-    pub fn advance_lines(lines: u32) -> Self {
-        Self {
-            delta_line: lines,
-            delta_start: 0,
-        }
-    }
-}
-
-impl ops::Add for PositionDelta {
-    type Output = PositionDelta;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        if rhs.delta_line == 0 {
-            Self {
-                delta_line: self.delta_line,
-                delta_start: self.delta_start + rhs.delta_start,
-            }
-        } else {
-            Self {
-                delta_line: self.delta_line + rhs.delta_line,
-                delta_start: rhs.delta_start,
-            }
-        }
-    }
-}
-
-impl ops::Sub for PositionDelta {
-    type Output = PositionDelta;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        let delta_line = self.delta_line - rhs.delta_line;
-
-        if delta_line == 0 {
-            // new start is on the same line as this token
-            Self {
-                delta_line,
-                delta_start: self.delta_start - rhs.delta_start,
-            }
-        } else {
-            Self {
-                delta_line,
-                delta_start: self.delta_start,
-            }
-        }
-    }
-}
-
-pub trait SemanticTokenExt {
-    /// Gets the position of the start of the token relative to the start of the last token
-    fn get_relative_position(&self) -> PositionDelta;
-    fn with_relative_position(&self, position: PositionDelta) -> Self;
-    fn with_length(&self, length: u32) -> Self;
-}
-
-impl SemanticTokenExt for SemanticToken {
-    fn get_relative_position(&self) -> PositionDelta {
-        PositionDelta {
-            delta_line: self.delta_line,
-            delta_start: self.delta_start,
-        }
-    }
-
-    fn with_relative_position(&self, position: PositionDelta) -> Self {
-        Self {
-            delta_line: position.delta_line,
-            delta_start: position.delta_start,
-            ..*self
-        }
-    }
-
-    fn with_length(&self, length: u32) -> Self {
-        Self { length, ..*self }
-    }
 }

--- a/src/server/semantic_tokens/mod.rs
+++ b/src/server/semantic_tokens/mod.rs
@@ -194,8 +194,9 @@ fn token_from_node(node: &LinkedNode) -> Option<TokenType> {
         Heading | HeadingMarker => Some(TokenType::Heading),
         ListMarker | EnumMarker | TermMarker => Some(TokenType::ListMarker),
         MathAlignPoint | Plus | Minus | Slash | Hat | Dot | Eq | EqEq | ExclEq | Lt | LtEq | Gt
-        | GtEq | PlusEq | HyphEq | StarEq | SlashEq | Dots | Arrow | Not | And | Or | Unary
-        | Binary => Some(TokenType::Operator),
+        | GtEq | PlusEq | HyphEq | StarEq | SlashEq | Dots | Arrow | Not | And | Or => {
+            Some(TokenType::Operator)
+        }
         Dollar => Some(TokenType::Delimiter),
         None | Auto | Let | Show | If | Else | For | In | While | Break | Continue | Return
         | Import | Include | As | Set => Some(TokenType::Keyword),

--- a/src/server/semantic_tokens/token_encode.rs
+++ b/src/server/semantic_tokens/token_encode.rs
@@ -1,9 +1,8 @@
-use itertools::Itertools;
 use tower_lsp::lsp_types::{Position, SemanticToken};
 use typst_library::prelude::EcoString;
 
 use crate::config::PositionEncoding;
-use crate::ext::{PositionDelta, PositionExt, SemanticTokenExt, StrExt};
+use crate::ext::{PositionExt, StrExt};
 use crate::lsp_typst_boundary::typst_to_lsp;
 use crate::workspace::source::Source;
 
@@ -20,33 +19,6 @@ pub(super) fn encode_tokens<'a>(
         *last_position = position;
         Some((encoded_token, source_code))
     })
-}
-
-/// Splits a maybe multiline [`SemanticToken`] into single line tokens, and provides a delta from
-/// the original position
-pub(super) fn split_lsp_token(
-    token: SemanticToken,
-    delta_to_start: PositionDelta,
-    source: &str,
-    encoding: PositionEncoding,
-) -> (impl Iterator<Item = SemanticToken>, PositionDelta) {
-    let mut lines = source
-        .split('\n') // we can't use `.lines()` since it drops end lines, which we need to count
-        .map(|line| line.trim_end()) // remove stray '\r'. trimming start messes up `offset`
-        .map(|line| line.encoded_len(encoding) as u32);
-
-    let first = lines.next().map(|length| {
-        let start = token.get_relative_position() - delta_to_start;
-        token.with_relative_position(start).with_length(length)
-    });
-    let rest = lines.map(|length| {
-        let start = PositionDelta::advance_lines(1);
-        token.with_relative_position(start).with_length(length)
-    });
-
-    let tokens = first.into_iter().chain(rest).collect_vec();
-    let delta = PositionDelta::advance_lines((tokens.len() - 1) as u32);
-    (tokens.into_iter(), delta)
 }
 
 fn encode_token(


### PR DESCRIPTION
- Use correct highlighting for variables
- Don't highlight entire expressions as operators
- Remove unneeded code