### PR TITLE
draft 1: making headings collapsible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
+ "bytes",
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ tokio = { version = "1.26.0", features = [
     "macros",
     "rt-multi-thread",
     "io-std",
+    "fs",
+    "io-util"
 ] }
 tower-lsp = "0.19.0"
 typst = { git = "https://github.com/typst/typst.git", tag = "v0.5.0" }


### PR DESCRIPTION
## _Draft_ Implementation of [collapsible headings feature request](https://github.com/nvarner/typst-lsp/issues/165)

### questions
- i find that the code has become quite dense, may i move the functionality to a new file? (src/server/folding.rs)
- it looks like the vscode folding is overridden by language server folding, [thus folding does not work for code at the moment.](https://github.com/nvarner/typst-lsp/assets/106487517/80b67e63-3110-49b3-a06b-fd104a6d0c14). Therefore: should the code folding also exist beside the heading folding?
- do you recognize any shortcuts to use already existing functionality (e.g. from the compiler)?
- which styling do you like better: [compact](https://github.com/nvarner/typst-lsp/assets/106487517/d6f0f7f9-9672-4b0b-bc4f-6b6e602f31a9) or [normal](https://github.com/nvarner/typst-lsp/assets/106487517/6c4b1d30-98fd-4ebe-903b-0b1e6813e217)? (i like the compact one)
- as you saw in the pictures above, level 1 headings do not wrap around level 2 headings..., at the moment all headings are collapsible independently, would you expect from folding that a level 1 heading collapses everything until the next level 1 heading or do you like the way it is now?
