### PR TITLE
Ensure id set and sources vec stay in sync

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,10 @@
           ];
 
           RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+
+          # Required by the jaeger feature
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
         };
 
         packages.default = rustPlatform.buildRustPackage {


### PR DESCRIPTION
Previously, an ID was always generated for each new URL by the source manager, but there wouldn't always be a corresponding insertion into the actual sources cache.

This commit fixes the issue by removing the added ID entry when an error occurs and a source item could not be added to the cache.

Should fix #183 