### PR TITLE
Correctly identify which workspace folder a file belongs to

### DIFF
--- a/src/server/command.rs
+++ b/src/server/command.rs
@@ -69,7 +69,7 @@ impl TypstServer {
             jsonrpc::Error::internal_error()
         })?;
 
-        self.thread(|_| comemo::evict(0)).await;
+        self.typst(|_| comemo::evict(0)).await;
 
         Ok(())
     }

--- a/src/server/export.rs
+++ b/src/server/export.rs
@@ -10,16 +10,16 @@ use super::TypstServer;
 impl TypstServer {
     #[tracing::instrument(skip(self))]
     pub async fn export_pdf(&self, source_uri: &Url, document: Document) -> anyhow::Result<()> {
-        let data = self.thread(move |_| typst::export::pdf(&document)).await;
         let pdf_uri = source_uri.clone().with_extension("pdf")?;
         info!(%pdf_uri, "exporting PDF");
 
-        let thread_uri = pdf_uri.clone();
         self.thread_with_world(&pdf_uri)
             .await?
             .run(move |world| {
+                let data = typst::export::pdf(&document);
+
                 world
-                    .write_raw(&thread_uri, &data)
+                    .write_raw(&pdf_uri, &data)
                     .context("failed to export PDF")
             })
             .await?;

--- a/src/workspace/package/manager.rs
+++ b/src/workspace/package/manager.rs
@@ -83,6 +83,8 @@ impl PackageManager {
         let package_id = PackageId::new_current(best_package_root.clone());
         let full_file_id = FullFileId::new(package_id, best_path);
 
+        trace!(?full_file_id, "chose full id!");
+
         Some(full_file_id)
     }
 

--- a/src/workspace/project.rs
+++ b/src/workspace/project.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::sync::Arc;
 
 use comemo::Prehashed;
 use tokio::sync::OwnedRwLockReadGuard;
@@ -14,14 +15,18 @@ use super::fs::FsResult;
 use super::package::{FullFileId, PackageId};
 use super::{Workspace, TYPST_STDLIB};
 
+#[derive(Clone)]
 pub struct Project {
     current: PackageId,
-    workspace: OwnedRwLockReadGuard<Workspace>,
+    workspace: Arc<OwnedRwLockReadGuard<Workspace>>,
 }
 
 impl Project {
     pub fn new(current: PackageId, workspace: OwnedRwLockReadGuard<Workspace>) -> Self {
-        Self { current, workspace }
+        Self {
+            current,
+            workspace: Arc::new(workspace),
+        }
     }
 
     fn workspace(&self) -> &Workspace {

--- a/src/workspace/world/mod.rs
+++ b/src/workspace/world/mod.rs
@@ -23,14 +23,14 @@ pub mod typst_thread;
 #[derive(Debug)]
 pub struct ProjectWorld {
     project: Project,
-    main: Url,
+    main: Source,
     /// Current time. Will be cached lazily for consistency throughout a compilation.
     now: Now,
     handle: runtime::Handle,
 }
 
 impl ProjectWorld {
-    fn new(project: Project, main: Url, handle: runtime::Handle) -> Self {
+    fn new(project: Project, main: Source, handle: runtime::Handle) -> Self {
         Self {
             project,
             main,
@@ -75,9 +75,7 @@ impl World for ProjectWorld {
 
     #[tracing::instrument]
     fn main(&self) -> Source {
-        self.project
-            .read_source_by_uri(&self.main)
-            .expect("main should be chosen to exist when world is constructed")
+        self.main.clone()
     }
 
     #[tracing::instrument]

--- a/src/workspace/world/typst_thread.rs
+++ b/src/workspace/world/typst_thread.rs
@@ -3,8 +3,8 @@ use std::thread;
 
 use tokio::runtime;
 use tokio::sync::oneshot;
-use tower_lsp::lsp_types::Url;
 use tracing::{trace, warn};
+use typst::syntax::Source;
 
 use crate::workspace::project::Project;
 
@@ -36,11 +36,11 @@ impl Default for TypstThread {
 }
 
 impl TypstThread {
-    #[tracing::instrument(skip(self, world_main, f), fields(%world_main))]
+    #[tracing::instrument(skip(self, f))]
     pub async fn run_with_world<Ret: Send + 'static>(
         &self,
         world_project: Project,
-        world_main: Url,
+        world_main: Source,
         f: impl FnOnce(ProjectWorld) -> Ret + Send + 'static,
     ) -> Ret {
         let f_prime = move |handle| {


### PR DESCRIPTION
Prevents a crash mentioned in #232 caused by multi-root workspaces.