### PR TITLE
Add Markdown-style list continuation, indent and dedent

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -9,9 +9,11 @@
             "version": "0.9.3",
             "license": "Apache-2.0 OR MIT",
             "dependencies": {
+                "markdown-it": "^12.3.2",
                 "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
+                "@types/markdown-it": "^13.0.0",
                 "@types/node": "^20.4.9",
                 "@types/vscode": "~1.71.0",
                 "@typescript-eslint/eslint-plugin": "^6.3.0",
@@ -528,6 +530,28 @@
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true
         },
+        "node_modules/@types/linkify-it": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+            "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+            "dev": true
+        },
+        "node_modules/@types/markdown-it": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.0.tgz",
+            "integrity": "sha512-mPTaUl5glYfzdJFeCsvhXQwZKdyszNAZcMm5ZTP5SfpTu+vIbog7J3z8Fa4x/Fzv5TB4R6OA/pHBYIYmkYOWGQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/linkify-it": "*",
+                "@types/mdurl": "*"
+            }
+        },
+        "node_modules/@types/mdurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+            "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+            "dev": true
+        },
         "node_modules/@types/node": {
             "version": "20.5.0",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
@@ -834,8 +858,7 @@
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.0",
@@ -2843,7 +2866,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
             "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-            "dev": true,
             "dependencies": {
                 "uc.micro": "^1.0.1"
             }
@@ -2884,7 +2906,6 @@
             "version": "12.3.2",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
             "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-            "dev": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "~2.1.0",
@@ -2900,7 +2921,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
             "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -2908,8 +2928,7 @@
         "node_modules/mdurl": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-            "dev": true
+            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -4071,8 +4090,7 @@
         "node_modules/uc.micro": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-            "dev": true
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
         },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -89,19 +89,19 @@
                     "typst.markdown.extension.orderedList.autoRenumber": {
                         "type": "boolean",
                         "default": true,
-                        "description": "%config.orderedList.autoRenumber.description%"
+                        "description": "Auto fix ordered list markers."
                     },
                     "typst.markdown.extension.orderedList.marker": {
                         "type": "string",
                         "default": "ordered",
-                        "description": "%config.orderedList.marker.description%",
+                        "description": "Ordered list marker.",
                         "enum": [
                             "one",
                             "ordered"
                         ],
                         "markdownEnumDescriptions": [
-                            "%config.orderedList.marker.enumDescriptions.one%",
-                            "%config.orderedList.marker.enumDescriptions.ordered%"
+                            "Always use 1. as ordered list marker.",
+                            "Use increasing numbers as ordered list marker."
                         ]
                     },
                     "typst.markdown.extension.list.indentationSize": {
@@ -111,11 +111,11 @@
                             "inherit"
                         ],
                         "markdownEnumDescriptions": [
-                            "%config.list.indentationSize.enumDescriptions.adaptive%",
-                            "%config.list.indentationSize.enumDescriptions.inherit%"
+                            "Adaptive indentation size according to the context, trying to left align the sublist with its parent's content.",
+                            "Use the configured tab size of the current document (see the status bar)."
                         ],
                         "default": "adaptive",
-                        "markdownDescription": "%config.list.indentationSize.description%",
+                        "markdownDescription": "Whether to use different indentation sizes on different list contexts or stick to VS Code's tab size.",
                         "scope": "resource"
                     }
                 }
@@ -413,8 +413,7 @@
         "test": ""
     },
     "dependencies": {
-        "vscode-languageclient": "^8.1.0",
-        "markdown-it": "^12.3.2"
+        "vscode-languageclient": "^8.1.0"    
     },
     "devDependencies": {
         "@types/markdown-it": "^13.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -16,77 +16,186 @@
     },
     "main": "./out/extension.js",
     "contributes": {
-        "configuration": {
-            "type": "object",
-            "title": "Typst LSP",
-            "properties": {
-                "typst-lsp.exportPdf": {
-                    "title": "Export PDF",
-                    "description": "The extension can export PDFs of your Typst files. This setting controls whether this feature is enabled and how often it runs.",
-                    "type": "string",
-                    "default": "onSave",
-                    "enum": [
-                        "never",
-                        "onSave",
-                        "onType"
-                    ],
-                    "enumDescriptions": [
-                        "Never export PDFs, you will manually run typst.",
-                        "Export PDFs when you save a file.",
-                        "Export PDFs as you type in a file."
-                    ]
-                },
-                "typst-lsp.rootPath": {
-                    "title": "Root path",
-                    "description": "Configure the root for absolute paths in typst",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null
-                },
-                "typst-lsp.semanticTokens": {
-                    "title": "Semantic tokens mode",
-                    "description": "Enable or disable semantic tokens (LSP syntax highlighting)",
-                    "type": "string",
-                    "default": "enable",
-                    "enum": [
-                        "enable",
-                        "disable"
-                    ],
-                    "enumDescriptions": [
-                        "Use semantic tokens for syntax highlighting",
-                        "Do not use semantic tokens for syntax highlighting"
-                    ]
-                },
-                "typst-lsp.serverPath": {
-                    "title": "Path to server executable",
-                    "description": "The extension can use a local typst-lsp executable instead of the one bundled with the extension. This setting controls the path to the executable.",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null
-                },
-                "typst-lsp.trace.server": {
-                    "scope": "window",
-                    "type": "string",
-                    "enum": [
-                        "off",
-                        "messages",
-                        "verbose"
-                    ],
-                    "default": "off",
-                    "description": "Traces the communication between VS Code and the language server."
+        "configuration": [
+            {
+                "type": "object",
+                "title": "Typst LSP",
+                "properties": {
+                    "typst-lsp.exportPdf": {
+                        "title": "Export PDF",
+                        "description": "The extension can export PDFs of your Typst files. This setting controls whether this feature is enabled and how often it runs.",
+                        "type": "string",
+                        "default": "onSave",
+                        "enum": [
+                            "never",
+                            "onSave",
+                            "onType"
+                        ],
+                        "enumDescriptions": [
+                            "Never export PDFs, you will manually run typst.",
+                            "Export PDFs when you save a file.",
+                            "Export PDFs as you type in a file."
+                        ]
+                    },
+                    "typst-lsp.rootPath": {
+                        "title": "Root path",
+                        "description": "Configure the root for absolute paths in typst",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "default": null
+                    },
+                    "typst-lsp.semanticTokens": {
+                        "title": "Semantic tokens mode",
+                        "description": "Enable or disable semantic tokens (LSP syntax highlighting)",
+                        "type": "string",
+                        "default": "enable",
+                        "enum": [
+                            "enable",
+                            "disable"
+                        ],
+                        "enumDescriptions": [
+                            "Use semantic tokens for syntax highlighting",
+                            "Do not use semantic tokens for syntax highlighting"
+                        ]
+                    },
+                    "typst-lsp.serverPath": {
+                        "title": "Path to server executable",
+                        "description": "The extension can use a local typst-lsp executable instead of the one bundled with the extension. This setting controls the path to the executable.",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "default": null
+                    },
+                    "typst-lsp.trace.server": {
+                        "scope": "window",
+                        "type": "string",
+                        "enum": [
+                            "off",
+                            "messages",
+                            "verbose"
+                        ],
+                        "default": "off",
+                        "description": "Traces the communication between VS Code and the language server."
+                    }
+                }
+            },
+            {
+                "type": "object",
+                "title": "Typst Markdown",
+                "properties": {
+                    "typst.markdown.extension.orderedList.autoRenumber": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "%config.orderedList.autoRenumber.description%"
+                    },
+                    "typst.markdown.extension.orderedList.marker": {
+                        "type": "string",
+                        "default": "ordered",
+                        "description": "%config.orderedList.marker.description%",
+                        "enum": [
+                            "one",
+                            "ordered"
+                        ],
+                        "markdownEnumDescriptions": [
+                            "%config.orderedList.marker.enumDescriptions.one%",
+                            "%config.orderedList.marker.enumDescriptions.ordered%"
+                        ]
+                    },
+                    "typst.markdown.extension.list.indentationSize": {
+                        "type": "string",
+                        "enum": [
+                            "adaptive",
+                            "inherit"
+                        ],
+                        "markdownEnumDescriptions": [
+                            "%config.list.indentationSize.enumDescriptions.adaptive%",
+                            "%config.list.indentationSize.enumDescriptions.inherit%"
+                        ],
+                        "default": "adaptive",
+                        "markdownDescription": "%config.list.indentationSize.description%",
+                        "scope": "resource"
+                    }
                 }
             }
-        },
+        ],
         "configurationDefaults": {
             "[typst]": {
                 "editor.wordWrap": "on",
                 "editor.semanticHighlighting.enabled": true
             }
         },
+        "keybindings": [
+            {
+                "command": "typst.markdown.extension.onEnterKey",
+                "key": "enter",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible && !editorHasMultipleSelections && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
+            },
+            {
+                "command": "typst.markdown.extension.onCtrlEnterKey",
+                "key": "ctrl+enter",
+                "mac": "cmd+enter",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible && !editorHasMultipleSelections"
+            },
+            {
+                "command": "typst.markdown.extension.onShiftEnterKey",
+                "key": "shift+enter",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible && !editorHasMultipleSelections"
+            },
+            {
+                "command": "typst.markdown.extension.onTabKey",
+                "key": "tab",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible && !inlineSuggestionVisible && !editorHasMultipleSelections && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions && typst.markdown.extension.editor.cursor.inList"
+            },
+            {
+                "command": "typst.markdown.extension.onShiftTabKey",
+                "key": "shift+tab",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible && !editorHasMultipleSelections && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions && typst.markdown.extension.editor.cursor.inList"
+            },
+            {
+                "command": "typst.markdown.extension.onBackspaceKey",
+                "key": "backspace",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible && !editorHasMultipleSelections && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
+            },
+            {
+                "command": "typst.markdown.extension.onMoveLineUp",
+                "key": "alt+up",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible"
+            },
+            {
+                "command": "typst.markdown.extension.onMoveLineDown",
+                "key": "alt+down",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible"
+            },
+            {
+                "command": "typst.markdown.extension.onCopyLineUp",
+                "win": "shift+alt+up",
+                "mac": "shift+alt+up",
+                "linux": "ctrl+shift+alt+up",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible"
+            },
+            {
+                "command": "typst.markdown.extension.onCopyLineDown",
+                "win": "shift+alt+down",
+                "mac": "shift+alt+down",
+                "linux": "ctrl+shift+alt+down",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == typst && !suggestWidgetVisible"
+            },
+            {
+                "command": "typst.markdown.extension.onIndentLines",
+                "key": "ctrl+]",
+                "mac": "cmd+]",
+                "when": "editorTextFocus && editorLangId == typst && !suggestWidgetVisible"
+            },
+            {
+                "command": "typst.markdown.extension.onOutdentLines",
+                "key": "ctrl+[",
+                "mac": "cmd+[",
+                "when": "editorTextFocus && editorLangId == typst && !suggestWidgetVisible"
+            }
+        ],
         "languages": [
             {
                 "id": "typst",
@@ -269,18 +378,18 @@
             "commandPalette": [
                 {
                     "command": "typst-lsp.exportCurrentPdf",
-                    "when": "editorLangId == typst"
+                    "when": "editorLangId === typst"
                 },
                 {
                     "command": "typst-lsp.clearCache",
-                    "when": "editorLangId == typst"
+                    "when": "editorLangId === typst"
                 }
             ],
             "editor/title": [
                 {
                     "command": "typst-lsp.showPdf",
                     "group": "navigation",
-                    "when": "editorLangId == typst"
+                    "when": "editorLangId === typst"
                 }
             ]
         }
@@ -304,21 +413,23 @@
         "test": ""
     },
     "dependencies": {
-        "vscode-languageclient": "^8.1.0"
+        "vscode-languageclient": "^8.1.0",
+        "markdown-it": "^12.3.2"
     },
     "devDependencies": {
+        "@types/markdown-it": "^13.0.0",
         "@types/node": "^20.4.9",
         "@types/vscode": "~1.71.0",
         "@typescript-eslint/eslint-plugin": "^6.3.0",
         "@typescript-eslint/parser": "^6.3.0",
         "@vscode/vsce": "^2.20.1",
-        "ovsx": "^0.8.3",
         "esbuild": "^0.19.0",
         "eslint": "^8.46.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.0",
         "eslint-plugin-n": "^16.0.1",
         "eslint-plugin-promise": "^6.1.1",
+        "ovsx": "^0.8.3",
         "prettier": "^3.0.1",
         "typescript": "^5.1.6"
     }

--- a/editors/vscode/src/IDisposable.ts
+++ b/editors/vscode/src/IDisposable.ts
@@ -1,0 +1,39 @@
+// From https://github.com/yzhang-gh/vscode-markdown/ , under the following license:
+// 
+// MIT License
+
+// Copyright (c) 2017 张宇
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+"use strict";
+
+/**
+ * @see <https://code.visualstudio.com/api/references/vscode-api#Disposable>
+ * @see <https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/IDisposable.cs>
+ * @see <https://referencesource.microsoft.com/#mscorlib/system/idisposable.cs>
+ */
+export default interface IDisposable {
+
+    /**
+     * Performs application-defined tasks associated with freeing, releasing, or resetting resources.
+     */
+    dispose(): any;
+}

--- a/editors/vscode/src/editor-context-service/context-service-in-list.ts
+++ b/editors/vscode/src/editor-context-service/context-service-in-list.ts
@@ -1,0 +1,61 @@
+// From https://github.com/yzhang-gh/vscode-markdown/ , under the following license:
+// 
+// MIT License
+
+// Copyright (c) 2017 张宇
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+'use strict'
+
+import { ExtensionContext, Position, TextDocument, window } from 'vscode';
+import { AbsContextService } from "./i-context-service";
+
+export class ContextServiceEditorInList extends AbsContextService {
+    public contextName: string = "typst.markdown.extension.editor.cursor.inList";
+
+    public onActivate(_context: ExtensionContext) {
+        // set initial state of context
+        this.setState(false);
+    }
+
+    public dispose(): void { }
+
+    public onDidChangeActiveTextEditor(document: TextDocument, cursorPos: Position) {
+        this.updateContextState(document, cursorPos);
+    }
+
+    public onDidChangeTextEditorSelection(document: TextDocument, cursorPos: Position) {
+        this.updateContextState(document, cursorPos);
+    }
+
+    private updateContextState(document: TextDocument, cursorPos: Position) {
+        let lineText = document.lineAt(cursorPos.line).text;
+
+        let inList = /^\s*([-+*]|[0-9]+[.)]) +(\[[ x]\] +)?/.test(lineText);
+        if (inList) {
+            this.setState(true);
+        }
+        else {
+            this.setState(false);
+        }
+        return;
+    }
+}

--- a/editors/vscode/src/editor-context-service/i-context-service.ts
+++ b/editors/vscode/src/editor-context-service/i-context-service.ts
@@ -1,0 +1,74 @@
+// From https://github.com/yzhang-gh/vscode-markdown/ , under the following license:
+// 
+// MIT License
+
+// Copyright (c) 2017 张宇
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+'use strict'
+
+import { commands, ExtensionContext, Position, TextDocument } from 'vscode';
+import type IDisposable from "../IDisposable";
+
+interface IContextService extends IDisposable {
+    onActivate(context: ExtensionContext): void;
+
+    /**
+     * handler of onDidChangeActiveTextEditor
+     * implement this method to handle that event to update context state
+     */
+    onDidChangeActiveTextEditor(document: TextDocument, cursorPos: Position): void;
+    /**
+     * handler of onDidChangeTextEditorSelection
+     * implement this method to handle that event to update context state
+     */
+    onDidChangeTextEditorSelection(document: TextDocument, cursorPos: Position): void;
+}
+
+export abstract class AbsContextService implements IContextService {
+    public abstract readonly contextName: string;
+
+    /**
+     * activate context service
+     * @param context ExtensionContext
+     */
+    public abstract onActivate(context: ExtensionContext): void;
+    public abstract dispose(): void;
+
+    /**
+     * default handler of onDidChangeActiveTextEditor, do nothing.
+     * override this method to handle that event to update context state.
+     */
+    public abstract onDidChangeActiveTextEditor(document: TextDocument, cursorPos: Position): void;
+
+    /**
+    * default handler of onDidChangeTextEditorSelection, do nothing.
+    * override this method to handle that event to update context state.
+    */
+    public abstract onDidChangeTextEditorSelection(document: TextDocument, cursorPos: Position): void;
+
+    /**
+     * set state of context
+     */
+    protected setState(state: any) {
+        commands.executeCommand('setContext', this.contextName, state);
+    }
+}

--- a/editors/vscode/src/editor-context-service/manager.ts
+++ b/editors/vscode/src/editor-context-service/manager.ts
@@ -1,0 +1,94 @@
+// From https://github.com/yzhang-gh/vscode-markdown/ , under the following license:
+// 
+// MIT License
+
+// Copyright (c) 2017 张宇
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+'use strict'
+
+import type IDisposable from "../IDisposable";
+import { ExtensionContext, window } from 'vscode';
+import { AbsContextService } from "./i-context-service";
+import { ContextServiceEditorInList } from "./context-service-in-list";
+// import { ContextServiceEditorInFencedCodeBlock } from "./context-service-in-fenced-code-block";
+// import { ContextServiceEditorInMathEn } from "./context-service-in-math-env";
+
+export class ContextServiceManager implements IDisposable {
+    private readonly contextServices: Array<AbsContextService> = [];
+
+    public constructor() {
+        // push context services
+        this.contextServices.push(new ContextServiceEditorInList());
+        // this.contextServices.push(new ContextServiceEditorInFencedCodeBlock());
+        // this.contextServices.push(new ContextServiceEditorInMathEn());
+    }
+
+    public activate(context: ExtensionContext) {
+        for (const service of this.contextServices) {
+            service.onActivate(context);
+        }
+        // subscribe update handler for context
+        context.subscriptions.push(
+            window.onDidChangeActiveTextEditor(() => this.onDidChangeActiveTextEditor()),
+            window.onDidChangeTextEditorSelection(() => this.onDidChangeTextEditorSelection())
+        );
+        // initialize context state
+        this.onDidChangeActiveTextEditor();
+    }
+
+    public dispose(): void {
+        while (this.contextServices.length > 0) {
+            const service = this.contextServices.pop();
+            service!.dispose();
+        }
+    }
+
+    private onDidChangeActiveTextEditor() {
+        const editor = window.activeTextEditor;
+        if (editor === undefined) {
+            return;
+        }
+
+        const cursorPos = editor.selection.start;
+        const document = editor.document;
+
+        for (const service of this.contextServices) {
+            service.onDidChangeActiveTextEditor(document, cursorPos);
+        }
+    }
+
+    private onDidChangeTextEditorSelection() {
+        const editor = window.activeTextEditor;
+        if (editor === undefined) {
+            return;
+        }
+
+        const cursorPos = editor.selection.start;
+        const document = editor.document;
+
+        for (const service of this.contextServices) {
+            service.onDidChangeTextEditorSelection(document, cursorPos);
+        }
+    }
+}
+
+export const contextServiceManager = new ContextServiceManager();

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -7,8 +7,10 @@ import {
     Uri,
     WorkspaceConfiguration,
 } from "vscode";
+import { contextServiceManager } from "./editor-context-service/manager"
 import * as path from "path";
 import * as child_process from "child_process";
+import * as listEditing from './listEditing';
 
 import {
     LanguageClient,
@@ -19,6 +21,16 @@ import {
 let client: LanguageClient | undefined = undefined;
 
 export function activate(context: ExtensionContext): Promise<void> {
+    context.subscriptions.push(
+        contextServiceManager
+    );
+
+    // Context services
+    contextServiceManager.activate(context);
+    
+    // Override `Enter`, `Tab` and `Backspace` keys
+    listEditing.activate(context);
+    
     return startClient(context).catch((e) => {
         void window.showErrorMessage(`Failed to activate typst-lsp: ${e}`);
         throw e;

--- a/editors/vscode/src/listEditing.ts
+++ b/editors/vscode/src/listEditing.ts
@@ -1,0 +1,567 @@
+// From https://github.com/yzhang-gh/vscode-markdown/ , under the following license:
+// 
+// MIT License
+
+// Copyright (c) 2017 张宇
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+
+import { commands, ExtensionContext, Position, Range, Selection, TextEditor, window, workspace, WorkspaceEdit } from 'vscode';
+// import { isInFencedCodeBlock, mathEnvCheck } from "./util/contextCheck";
+
+type IModifier = "ctrl" | "shift";
+
+export function activate(context: ExtensionContext) {
+    context.subscriptions.push(
+        commands.registerCommand('typst.markdown.extension.onEnterKey', onEnterKey),
+        commands.registerCommand('typst.markdown.extension.onCtrlEnterKey', () => { return onEnterKey('ctrl'); }),
+        commands.registerCommand('typst.markdown.extension.onShiftEnterKey', () => { return onEnterKey('shift'); }),
+        commands.registerCommand('typst.markdown.extension.onTabKey', onTabKey),
+        commands.registerCommand('typst.markdown.extension.onShiftTabKey', () => { return onTabKey('shift'); }),
+        commands.registerCommand('typst.markdown.extension.onBackspaceKey', onBackspaceKey),
+        commands.registerCommand('typst.markdown.extension.checkTaskList', checkTaskList),
+        commands.registerCommand('typst.markdown.extension.onMoveLineDown', onMoveLineDown),
+        commands.registerCommand('typst.markdown.extension.onMoveLineUp', onMoveLineUp),
+        commands.registerCommand('typst.markdown.extension.onCopyLineDown', onCopyLineDown),
+        commands.registerCommand('typst.markdown.extension.onCopyLineUp', onCopyLineUp),
+        commands.registerCommand('typst.markdown.extension.onIndentLines', onIndentLines),
+        commands.registerCommand('typst.markdown.extension.onOutdentLines', onOutdentLines)
+    );
+}
+
+// The commands here are only bound to keys with `when` clause containing `editorTextFocus && !editorReadonly`. (package.json)
+// So we don't need to check whether `activeTextEditor` returns `undefined` in most cases.
+
+function onEnterKey(modifiers?: IModifier) {
+    const editor = window.activeTextEditor!;
+    let cursorPos: Position = editor.selection.active;
+    let line = editor.document.lineAt(cursorPos.line);
+    let textBeforeCursor = line.text.substr(0, cursorPos.character);
+    let textAfterCursor = line.text.substr(cursorPos.character);
+
+    let lineBreakPos = cursorPos;
+    if (modifiers == 'ctrl') {
+        lineBreakPos = line.range.end;
+    }
+
+    if (modifiers == 'shift') {
+        return asNormal(editor, 'enter', modifiers);
+    }
+
+    //// This is a possibility that the current line is a thematic break `<hr>` (GitHub #785)
+    const lineTextNoSpace = line.text.replace(/\s/g, '');
+    if (lineTextNoSpace.length > 2
+        && (
+            lineTextNoSpace.replace(/\-/g, '').length === 0
+            || lineTextNoSpace.replace(/\*/g, '').length === 0
+        )
+    ) {
+        return asNormal(editor, 'enter', modifiers);
+    }
+
+    //// If it's an empty list item, remove it
+    if (/^([-+*]|[0-9]+[.)])( +\[[ x]\])?$/.test(textBeforeCursor.trim()) && textAfterCursor.trim().length == 0) {
+        return editor.edit(editBuilder => {
+            editBuilder.delete(line.range);
+            editBuilder.insert(line.range.end, '\n');
+        }).then(() => {
+            editor.revealRange(editor.selection);
+        }).then(() => fixMarker(editor));
+    }
+
+    let matches: RegExpExecArray | null;
+    if (/^> /.test(textBeforeCursor)) {
+        // Block quotes
+
+        // Case 1: ending a blockquote if:
+        const isEmptyArrowLine = line.text.replace(/[ \t]+$/, '') === '>';
+        if (isEmptyArrowLine) {
+            if (cursorPos.line === 0) {
+                // it is an empty '>' line and also the first line of the document
+                return editor.edit(editorBuilder => {
+                    editorBuilder.replace(new Range(new Position(0, 0), new Position(cursorPos.line, cursorPos.character)), '');
+                }).then(() => { editor.revealRange(editor.selection) });
+            } else {
+                // there have been 2 consecutive empty `>` lines
+                const prevLineText = editor.document.lineAt(cursorPos.line - 1).text;
+                if (prevLineText.replace(/[ \t]+$/, '') === '>') {
+                    return editor.edit(editorBuilder => {
+                        editorBuilder.replace(new Range(new Position(cursorPos.line - 1, 0), new Position(cursorPos.line, cursorPos.character)), '\n');
+                    }).then(() => { editor.revealRange(editor.selection) });
+                }
+            }
+        }
+
+        // Case 2: `>` continuation
+        return editor.edit(editBuilder => {
+            if (isEmptyArrowLine) {
+                const startPos = new Position(cursorPos.line, line.text.trim().length);
+                editBuilder.delete(new Range(startPos, line.range.end));
+                lineBreakPos = startPos;
+            }
+            editBuilder.insert(lineBreakPos, `\n> `);
+        }).then(() => {
+            // Fix cursor position
+            if (modifiers == 'ctrl' && !cursorPos.isEqual(lineBreakPos)) {
+                let newCursorPos = cursorPos.with(line.lineNumber + 1, 2);
+                editor.selection = new Selection(newCursorPos, newCursorPos);
+            }
+        }).then(() => { editor.revealRange(editor.selection) });
+    } else if ((matches = /^((\s*[-+*] +)(\[[ x]\] +)?)/.exec(textBeforeCursor)) !== null) {
+        // satisfy compiler's null check
+        const match0 = matches[0];
+        const match1 = matches[1];
+        const match2 = matches[2];
+        const match3 = matches[3];
+
+        // Unordered list
+        return editor.edit(editBuilder => {
+            if (
+                match3 &&                       // If it is a task list item and
+                match0 === textBeforeCursor &&  // the cursor is right after the checkbox "- [x] |item1"
+                modifiers !== 'ctrl'
+            ) {
+                // Move the task list item to the next line
+                // - [x] |item1
+                // ↓
+                // - [ ] 
+                // - [x] |item1
+                editBuilder.replace(new Range(cursorPos.line, match2.length + 1, cursorPos.line, match2.length + 2), " ");
+                editBuilder.insert(lineBreakPos, `\n${match1}`);
+            } else {
+                // Insert "- [ ]"
+                // - [ ] item1|
+                // ↓
+                // - [ ] item1
+                // - [ ] |
+                editBuilder.insert(lineBreakPos, `\n${match1.replace('[x]', '[ ]')}`);
+            }
+        }).then(() => {
+            // Fix cursor position
+            if (modifiers == 'ctrl' && !cursorPos.isEqual(lineBreakPos)) {
+                let newCursorPos = cursorPos.with(line.lineNumber + 1, matches![1].length);
+                editor.selection = new Selection(newCursorPos, newCursorPos);
+            }
+        }).then(() => { editor.revealRange(editor.selection) });
+    } else if ((matches = /^(\s*)([0-9]+)([.)])( +)((\[[ x]\] +)?)/.exec(textBeforeCursor)) !== null) {
+        // Ordered list
+        let config = workspace.getConfiguration('typst.markdown.extension.orderedList').get<string>('marker');
+        let marker = '1';
+        let leadingSpace = matches[1];
+        let previousMarker = matches[2];
+        let delimiter = matches[3];
+        let trailingSpace = matches[4];
+        let gfmCheckbox = matches[5].replace('[x]', '[ ]');
+        let textIndent = (previousMarker + delimiter + trailingSpace).length;
+        if (config == 'ordered') {
+            marker = String(Number(previousMarker) + 1);
+        }
+        // Add enough trailing spaces so that the text is aligned with the previous list item, but always keep at least one space
+        trailingSpace = " ".repeat(Math.max(1, textIndent - (marker + delimiter).length));
+
+        const toBeAdded = leadingSpace + marker + delimiter + trailingSpace + gfmCheckbox;
+        return editor.edit(
+            editBuilder => {
+                editBuilder.insert(lineBreakPos, `\n${toBeAdded}`);
+            },
+            { undoStopBefore: true, undoStopAfter: false }
+        ).then(() => {
+            // Fix cursor position
+            if (modifiers == 'ctrl' && !cursorPos.isEqual(lineBreakPos)) {
+                let newCursorPos = cursorPos.with(line.lineNumber + 1, toBeAdded.length);
+                editor.selection = new Selection(newCursorPos, newCursorPos);
+            }
+        }).then(() => fixMarker(editor)).then(() => { editor.revealRange(editor.selection); });
+    } else {
+        return asNormal(editor, 'enter', modifiers);
+    }
+}
+
+function onTabKey(modifiers?: IModifier) {
+    const editor = window.activeTextEditor!;
+    let cursorPos = editor.selection.start;
+    let lineText = editor.document.lineAt(cursorPos.line).text;
+
+    let match = /^\s*([-+*]|[0-9]+[.)]) +(\[[ x]\] +)?/.exec(lineText);
+    if (
+        match
+        && (
+            modifiers === 'shift'
+            || !editor.selection.isEmpty
+            || editor.selection.isEmpty && cursorPos.character <= match[0].length
+        )
+    ) {
+        if (modifiers === 'shift') {
+            return outdent(editor).then(() => fixMarker(editor));
+        } else {
+            return indent(editor).then(() => fixMarker(editor));
+        }
+    } else {
+        return asNormal(editor, 'tab', modifiers);
+    }
+}
+
+function onBackspaceKey() {
+    const editor = window.activeTextEditor!;
+    let cursor = editor.selection.active;
+    let document = editor.document;
+    let textBeforeCursor = document.lineAt(cursor.line).text.substr(0, cursor.character);
+
+    if (!editor.selection.isEmpty) {
+        return asNormal(editor, 'backspace').then(() => fixMarker(editor));
+    } else if (/^\s+([-+*]|[0-9]+[.)]) $/.test(textBeforeCursor)) {
+        // e.g. textBeforeCursor === `  - `, `   1. `
+        return outdent(editor).then(() => fixMarker(editor));
+    } else if (/^([-+*]|[0-9]+[.)]) $/.test(textBeforeCursor)) {
+        // e.g. textBeforeCursor === `- `, `1. `
+        return editor.edit(editBuilder => {
+            editBuilder.replace(new Range(cursor.with({ character: 0 }), cursor), ' '.repeat(textBeforeCursor.length))
+        }).then(() => fixMarker(editor));
+    } else if (/^\s*([-+*]|[0-9]+[.)]) +(\[[ x]\] )$/.test(textBeforeCursor)) {
+        // e.g. textBeforeCursor === `- [ ]`, `1. [x]`, `  - [x]`
+        return deleteRange(editor, new Range(cursor.with({ character: textBeforeCursor.length - 4 }), cursor)).then(() => fixMarker(editor));
+    } else {
+        return asNormal(editor, 'backspace');
+    }
+}
+
+function asNormal(editor: TextEditor, key: "backspace" | "enter" | "tab", modifiers?: IModifier) {
+    switch (key) {
+        case 'enter':
+            if (modifiers === 'ctrl') {
+                return commands.executeCommand('editor.action.insertLineAfter');
+            } else {
+                return commands.executeCommand('type', { source: 'keyboard', text: '\n' });
+            }
+        case 'tab':
+            if (modifiers === 'shift') {
+                return commands.executeCommand('editor.action.outdentLines');
+            } else if (
+                editor.selection.isEmpty
+                && workspace.getConfiguration('emmet').get<boolean>('triggerExpansionOnTab')
+            ) {
+                return commands.executeCommand('editor.emmet.action.expandAbbreviation');
+            } else {
+                return commands.executeCommand('tab');
+            }
+        case 'backspace':
+            return commands.executeCommand('deleteLeft');
+    }
+}
+
+/**
+ * If
+ *
+ * 1. it is not the first line
+ * 2. there is a Markdown list item before this line
+ *
+ * then indent the current line to align with the previous list item.
+ */
+function indent(editor: TextEditor) {
+    if (workspace.getConfiguration("typst.markdown.extension.list", editor.document.uri).get<string>("indentationSize") === "adaptive") {
+        try {
+            const selection = editor.selection;
+            const indentationSize = tryDetermineIndentationSize(editor, selection.start.line, editor.document.lineAt(selection.start.line).firstNonWhitespaceCharacterIndex);
+            let edit = new WorkspaceEdit()
+            for (let i = selection.start.line; i <= selection.end.line; i++) {
+                if (i === selection.end.line && !selection.isEmpty && selection.end.character === 0) {
+                    break;
+                }
+                if (editor.document.lineAt(i).text.length !== 0) {
+                    edit.insert(editor.document.uri, new Position(i, 0), ' '.repeat(indentationSize));
+                }
+            }
+            return workspace.applyEdit(edit);
+        } catch (error) { }
+    }
+
+    return commands.executeCommand('editor.action.indentLines');
+}
+
+/**
+ * Similar to `indent`-function
+ */
+function outdent(editor: TextEditor) {
+    if (workspace.getConfiguration("typst.markdown.extension.list", editor.document.uri).get<string>("indentationSize") === "adaptive") {
+        try {
+            const selection = editor.selection;
+            const indentationSize = tryDetermineIndentationSize(editor, selection.start.line, editor.document.lineAt(selection.start.line).firstNonWhitespaceCharacterIndex);
+            let edit = new WorkspaceEdit()
+            for (let i = selection.start.line; i <= selection.end.line; i++) {
+                if (i === selection.end.line && !selection.isEmpty && selection.end.character === 0) {
+                    break;
+                }
+                const lineText = editor.document.lineAt(i).text;
+                let maxOutdentSize: number;
+                if (lineText.trim().length === 0) {
+                    maxOutdentSize = lineText.length;
+                } else {
+                    maxOutdentSize = editor.document.lineAt(i).firstNonWhitespaceCharacterIndex;
+                }
+                if (maxOutdentSize > 0) {
+                    edit.delete(editor.document.uri, new Range(i, 0, i, Math.min(indentationSize, maxOutdentSize)));
+                }
+            }
+            return workspace.applyEdit(edit);
+        } catch (error) { }
+    }
+
+    return commands.executeCommand('editor.action.outdentLines');
+}
+
+function tryDetermineIndentationSize(editor: TextEditor, line: number, currentIndentation: number) {
+    while (--line >= 0) {
+        const lineText = editor.document.lineAt(line).text;
+        let matches;
+        if ((matches = /^(\s*)(([-+*]|[0-9]+[.)]) +)(\[[ x]\] +)?/.exec(lineText)) !== null) {
+            if (matches[1].length <= currentIndentation) {
+                return matches[2].length;
+            }
+        }
+    }
+    throw "No previous Markdown list item";
+}
+
+/**
+ * Returns the line index of the next ordered list item starting from the specified line.
+ *
+ * @param line
+ * Defaults to the beginning of the current primary selection (`editor.selection.start.line`)
+ * in order to find the first marker following either the cursor or the entire selected range.
+ */
+function findNextMarkerLineNumber(editor: TextEditor, line = editor.selection.start.line): number {
+    while (line < editor.document.lineCount) {
+        const lineText = editor.document.lineAt(line).text;
+
+        if (lineText.startsWith('#')) {
+            // Don't go searching past any headings
+            return -1;
+        }
+
+        if (/^\s*[0-9]+[.)] +/.exec(lineText) !== null) {
+            return line;
+        }
+        line++;
+    }
+    return -1;
+}
+
+/**
+ * Looks for the previous ordered list marker at the same indentation level
+ * and returns the marker number that should follow it.
+ * 
+ * @param currentIndentation treat tabs as if they were replaced by spaces with a tab stop of 4 characters
+ *
+ * @returns the fixed marker number
+ */
+function lookUpwardForMarker(editor: TextEditor, line: number, currentIndentation: number): number {
+    let prevLine = line;
+    while (--prevLine >= 0) {
+        const prevLineText = editor.document.lineAt(prevLine).text.replace(/\t/g, '    ');
+        let matches;
+        if ((matches = /^(\s*)(([0-9]+)[.)] +)/.exec(prevLineText)) !== null) {
+            // The previous line has an ordered list marker
+            const prevLeadingSpace: string = matches[1];
+            const prevMarker = matches[3];
+            if (currentIndentation < prevLeadingSpace.length) {
+                // yet to find a sibling item
+                continue;
+            } else if (
+                currentIndentation >= prevLeadingSpace.length
+                && currentIndentation <= (prevLeadingSpace + prevMarker).length
+            ) {
+                // found a sibling item
+                return Number(prevMarker) + 1;
+            } else if (currentIndentation > (prevLeadingSpace + prevMarker).length) {
+                // found a parent item
+                return 1;
+            } else {
+                // not possible
+            }
+        } else if ((matches = /^(\s*)([-+*] +)/.exec(prevLineText)) !== null) {
+            // The previous line has an unordered list marker
+            const prevLeadingSpace: string = matches[1];
+            if (currentIndentation >= prevLeadingSpace.length) {
+                // stop finding
+                break;
+            }
+        } else if ((matches = /^(\s*)\S/.exec(prevLineText)) !== null) {
+            // The previous line doesn't have a list marker
+            if (matches[1].length < 3) {
+                // no enough indentation for a list item
+                break;
+            }
+        }
+    }
+    return 1;
+}
+
+/**
+ * Fix ordered list marker *iteratively* starting from current line
+ */
+export function fixMarker(editor: TextEditor, line?: number): Thenable<unknown> | void {
+    if (!workspace.getConfiguration('typst.markdown.extension.orderedList').get<boolean>('autoRenumber')) return;
+    if (workspace.getConfiguration('typst.markdown.extension.orderedList').get<string>('marker') == 'one') return;
+
+    if (line === undefined) {
+        line = findNextMarkerLineNumber(editor);
+    }
+    if (line < 0 || line >= editor.document.lineCount) {
+        return;
+    }
+
+    let currentLineText = editor.document.lineAt(line).text;
+    let matches;
+    if ((matches = /^(\s*)([0-9]+)([.)])( +)/.exec(currentLineText)) !== null) { // ordered list
+        let leadingSpace = matches[1];
+        let marker = matches[2];
+        let delimiter = matches[3];
+        let trailingSpace = matches[4];
+        let fixedMarker = lookUpwardForMarker(editor, line, leadingSpace.replace(/\t/g, '    ').length);
+        let listIndent = marker.length + delimiter.length + trailingSpace.length;
+        let fixedMarkerString = String(fixedMarker);
+
+        return editor.edit(
+            // fix the marker (current line)
+            editBuilder => {
+                if (marker === fixedMarkerString) {
+                    return;
+                }
+                // Add enough trailing spaces so that the text is still aligned at the same indentation level as it was previously, but always keep at least one space
+                fixedMarkerString += delimiter + " ".repeat(Math.max(1, listIndent - (fixedMarkerString + delimiter).length));
+
+                editBuilder.replace(new Range(line!, leadingSpace.length, line!, leadingSpace.length + listIndent), fixedMarkerString);
+            },
+            { undoStopBefore: false, undoStopAfter: false }
+        ).then(() => {
+            let nextLine = line! + 1;
+            while (editor.document.lineCount > nextLine) {
+                const nextLineText = editor.document.lineAt(nextLine).text;
+                if (/^\s*[0-9]+[.)] +/.test(nextLineText)) {
+                    return fixMarker(editor, nextLine);
+                } else if (
+                    editor.document.lineAt(nextLine - 1).isEmptyOrWhitespace  // This line is a block
+                    && !nextLineText.startsWith(" ".repeat(3))                // and doesn't have enough indentation
+                    && !nextLineText.startsWith("\t")                         // so terminates the current list.
+                ) {
+                    return;
+                } else {
+                    nextLine++;
+                }
+            }
+        });
+    }
+}
+
+function deleteRange(editor: TextEditor, range: Range): Thenable<boolean> {
+    return editor.edit(
+        editBuilder => {
+            editBuilder.delete(range);
+        },
+        // We will enable undoStop after fixing markers
+        { undoStopBefore: true, undoStopAfter: false }
+    );
+}
+
+function checkTaskList(): Thenable<unknown> | void {
+    // - Look into selections for lines that could be checked/unchecked.
+    // - The first matching line dictates the new state for all further lines.
+    //   - I.e. if the first line is unchecked, only other unchecked lines will
+    //     be considered, and vice versa.
+    const editor = window.activeTextEditor!;
+    const uncheckedRegex = /^(\s*([-+*]|[0-9]+[.)]) +\[) \]/
+    const checkedRegex = /^(\s*([-+*]|[0-9]+[.)]) +\[)x\]/
+    let toBeToggled: Position[] = [] // all spots that have an "[x]" resp. "[ ]" which should be toggled
+    let newState: boolean | undefined = undefined // true = "x", false = " ", undefined = no matching lines
+
+    // go through all touched lines of all selections.
+    for (const selection of editor.selections) {
+        for (let i = selection.start.line; i <= selection.end.line; i++) {
+            const line = editor.document.lineAt(i);
+            const lineStart = line.range.start;
+
+            if (!selection.isSingleLine && (selection.start.isEqual(line.range.end) || selection.end.isEqual(line.range.start))) {
+                continue;
+            }
+
+            let matches: RegExpExecArray | null;
+            if (
+                (matches = uncheckedRegex.exec(line.text))
+                && newState !== false
+            ) {
+                toBeToggled.push(lineStart.with({ character: matches[1].length }));
+                newState = true;
+            } else if (
+                (matches = checkedRegex.exec(line.text))
+                && newState !== true
+            ) {
+                toBeToggled.push(lineStart.with({ character: matches[1].length }));
+                newState = false;
+            }
+        }
+    }
+
+    if (newState !== undefined) {
+        const newChar = newState ? 'x' : ' ';
+        return editor.edit(editBuilder => {
+            for (const pos of toBeToggled) {
+                let range = new Range(pos, pos.with({ character: pos.character + 1 }));
+                editBuilder.replace(range, newChar);
+            }
+        });
+    }
+}
+
+function onMoveLineUp() {
+    const editor = window.activeTextEditor!;
+    return commands.executeCommand('editor.action.moveLinesUpAction')
+        .then(() => fixMarker(editor));
+}
+
+function onMoveLineDown() {
+    const editor = window.activeTextEditor!;
+    return commands.executeCommand('editor.action.moveLinesDownAction')
+        .then(() => fixMarker(editor, findNextMarkerLineNumber(editor, editor.selection.start.line - 1)));
+}
+
+function onCopyLineUp() {
+    const editor = window.activeTextEditor!;
+    return commands.executeCommand('editor.action.copyLinesUpAction')
+        .then(() => fixMarker(editor));
+}
+
+function onCopyLineDown() {
+    const editor = window.activeTextEditor!;
+    return commands.executeCommand('editor.action.copyLinesDownAction')
+        .then(() => fixMarker(editor));
+}
+
+function onIndentLines() {
+    const editor = window.activeTextEditor!;
+    return indent(editor).then(() => fixMarker(editor));
+}
+
+function onOutdentLines() {
+    const editor = window.activeTextEditor!;
+    return outdent(editor).then(() => fixMarker(editor));
+}
+
+export function deactivate() { }


### PR DESCRIPTION
This PR adds inuitive handling of Ordered and Unordered lists to `.typ` files.

- `Enter` while in a list context (either ordered or unordered) continues the existing list (with correct numbering, if ordered).
- `Tab` and `Shift+Tab` while in a list context (either ordered or unordered) indents and dedents bullets intuitively (and re-numbers ordered lists if appropriate).
- Reordering lines inside an ordered list automatically updates the list numbers accordingly.

Adapted, with attribution, from https://github.com/yzhang-gh/vscode-markdown/ , under the following license:

MIT License, Copyright (c) 2017 张宇