### PR TITLE
Read typstfmt config from files, if possible

### DIFF
--- a/src/server/formatting.rs
+++ b/src/server/formatting.rs
@@ -1,3 +1,6 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 
@@ -29,7 +32,7 @@ pub fn get_formatting_unregistration() -> Unregistration {
 impl TypstServer {
     pub async fn format_document(&self, source: &Source) -> anyhow::Result<Vec<TextEdit>> {
         let original_text = source.text();
-        let res = typstfmt_lib::format(original_text, self.get_fmt_config().await);
+        let res = typstfmt_lib::format(original_text, self.get_fmt_config().await?);
 
         Ok(vec![TextEdit {
             new_text: res,
@@ -46,25 +49,28 @@ impl TypstServer {
         }])
     }
 
-    async fn get_fmt_config(&self) -> FmtConfig {
+    async fn get_fmt_config(&self) -> anyhow::Result<FmtConfig> {
         // Ignoring all errors since we're returning the default config in case
         // we can't find something more specific
-        let mut config_file: Option<File> = File::options().read(true).open(CONFIG_PATH).await.ok();
+        let mut path = PathBuf::from(CONFIG_PATH);
+        let mut config_file: Option<File> = File::options().read(true).open(&path).await.ok();
 
         if config_file.is_none() {
             if let Some(root_path) = &self.config.read().await.root_path {
-                let mut root_path = root_path.clone();
-                root_path.push(CONFIG_PATH);
-                config_file = File::options().read(true).open(root_path).await.ok();
+                path = root_path.clone();
+                path.push(CONFIG_PATH);
+                config_file = File::options().read(true).open(&path).await.ok();
             }
         }
 
         if let Some(mut f) = config_file {
             let mut buf = String::default();
             let _ = f.read_to_string(&mut buf).await;
-            FmtConfig::from_toml(&buf).unwrap_or_default()
+            // An error here should be surfaced to the user though
+            FmtConfig::from_toml(&buf)
+                .map_err(|s| anyhow::anyhow!(s))
         } else {
-            FmtConfig::default()
+            Ok(FmtConfig::default())
         }
     }
 }

--- a/src/server/formatting.rs
+++ b/src/server/formatting.rs
@@ -1,10 +1,14 @@
+use std::{fs::File, io::Read};
+
 use tower_lsp::lsp_types::{Position, Range, Registration, TextEdit, Unregistration};
 use typst::syntax::Source;
+use typstfmt_lib::Config as FmtConfig;
 
 use super::TypstServer;
 
 const FORMATTING_REGISTRATION_ID: &str = "formatting";
 const DOCUMENT_FORMATTING_METHOD_ID: &str = "textDocument/formatting";
+const CONFIG_PATH: &str = "typstfmt-config.toml";
 
 pub fn get_formatting_registration() -> Registration {
     Registration {
@@ -24,7 +28,7 @@ pub fn get_formatting_unregistration() -> Unregistration {
 impl TypstServer {
     pub fn format_document(&self, source: &Source) -> anyhow::Result<Vec<TextEdit>> {
         let original_text = source.text();
-        let res = typstfmt_lib::format(original_text, typstfmt_lib::Config::default());
+        let res = typstfmt_lib::format(original_text, self.get_fmt_config());
 
         Ok(vec![TextEdit {
             new_text: res,
@@ -39,5 +43,28 @@ impl TypstServer {
                 },
             ),
         }])
+    }
+
+    fn get_fmt_config(&self) -> FmtConfig {
+        // Ignoring all errors since we're returning the default config in case
+        // we can't find something more specific
+        let mut config_file: Option<File> = File::options().read(true).open(CONFIG_PATH).ok();
+
+        if config_file.is_none() {
+            if let Some(root_path) = &self.config.blocking_read().root_path {
+                let mut root_path = root_path.clone();
+                root_path.push(CONFIG_PATH);
+                config_file = File::options().read(true).open(root_path).ok();
+            }
+        }
+
+        config_file
+            .map(|mut f| {
+                let mut buf = String::default();
+                let _ = f.read_to_string(&mut buf);
+                FmtConfig::from_toml(&buf).ok()
+            })
+            .flatten()
+            .unwrap_or_default()
     }
 }


### PR DESCRIPTION
If we have a `typstfmt-config.toml` in the working directory, use that. Otherwise, look for it in the project root. Otherwise, use the default config. This seemed the most sensible thing to me.