### PR TITLE
Add related information to typst diagnostics

### DIFF
--- a/src/lsp_typst_boundary.rs
+++ b/src/lsp_typst_boundary.rs
@@ -254,11 +254,10 @@ pub mod typst_to_lsp {
                 }));
             }
         }
-        
+
         Ok(None)
     }
-    
-    
+
     async fn diagnostic_related_information(
         project: &Project,
         typst_diagnostic: &TypstDiagnostic,
@@ -267,11 +266,13 @@ pub mod typst_to_lsp {
         let mut tracepoints = vec![];
 
         for tracepoint in &typst_diagnostic.trace {
-            if let Some(info) = tracepoint_to_relatedinformation(project, tracepoint, const_config).await? {
+            if let Some(info) =
+                tracepoint_to_relatedinformation(project, tracepoint, const_config).await?
+            {
                 tracepoints.push(info);
             }
         }
-        
+
         Ok(tracepoints)
     }
 
@@ -295,7 +296,8 @@ pub mod typst_to_lsp {
         let typst_hints = &typst_diagnostic.hints;
         let lsp_message = format!("{typst_message}{}", diagnostic_hints(typst_hints));
 
-        let tracepoints = diagnostic_related_information(project, typst_diagnostic, const_config).await?;
+        let tracepoints =
+            diagnostic_related_information(project, typst_diagnostic, const_config).await?;
 
         let diagnostic = LspDiagnostic {
             range: lsp_range.raw_range,

--- a/src/lsp_typst_boundary.rs
+++ b/src/lsp_typst_boundary.rs
@@ -255,7 +255,7 @@ pub mod typst_to_lsp {
             }
         }
         
-        return Ok(None);
+        Ok(None)
     }
     
     
@@ -267,7 +267,7 @@ pub mod typst_to_lsp {
         let mut tracepoints = vec![];
 
         for tracepoint in &typst_diagnostic.trace {
-            if let Some(info) = tracepoint_to_relatedinformation(project, &tracepoint, const_config).await? {
+            if let Some(info) = tracepoint_to_relatedinformation(project, tracepoint, const_config).await? {
                 tracepoints.push(info);
             }
         }


### PR DESCRIPTION
Adds related information to the diagnostics based on the trace points provided by typst itself.

This is my first time interacting with this codebase so if you spot anything that could be improved, please do let me know!

Before the change:
![Before](https://github.com/nvarner/typst-lsp/assets/32451103/abf97684-9401-4f00-93f9-bcf29851614e)

After the change:
![After](https://github.com/nvarner/typst-lsp/assets/32451103/c41b0520-0375-493a-b5d6-db51e5bc89a6)
