### PR TITLE
Don't build for VS Code target `win32-ia32`

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -15,11 +15,6 @@ jobs:
             vs-code-target: win32-x64
             features:
 
-          - os: windows-latest
-            rust-target: i686-pc-windows-msvc
-            vs-code-target: win32-ia32
-            features:
-
           # Ring fails to compile on this target, so don't use rustls
           - os: windows-latest
             rust-target: aarch64-pc-windows-msvc


### PR DESCRIPTION
Based on microsoft/vscode-vsce#908 and microsoft/vscode#195559, it appears that extensions should no longer be published for the now removed `win32-ia32` target.