### PR TITLE
Add auto complete for citations

### DIFF
--- a/src/server/document.rs
+++ b/src/server/document.rs
@@ -40,7 +40,7 @@ impl TypstServer {
     }
 
     pub async fn run_diagnostics(&self, uri: &Url) -> anyhow::Result<()> {
-        let (_, diagnostics) = self.eval_source(uri).await?;
+        let (_, diagnostics) = self.compile_source(uri).await?;
 
         self.update_all_diagnostics(diagnostics).await;
 

--- a/src/server/export.rs
+++ b/src/server/export.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::Context;
 use tower_lsp::lsp_types::Url;
 use tracing::info;
@@ -9,7 +11,11 @@ use super::TypstServer;
 
 impl TypstServer {
     #[tracing::instrument(skip(self))]
-    pub async fn export_pdf(&self, source_uri: &Url, document: Document) -> anyhow::Result<()> {
+    pub async fn export_pdf(
+        &self,
+        source_uri: &Url,
+        document: Arc<Document>,
+    ) -> anyhow::Result<()> {
         let pdf_uri = source_uri.clone().with_extension("pdf")?;
         info!(%pdf_uri, "exporting PDF");
 

--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -385,9 +385,7 @@ impl LanguageServer for TypstServer {
             .map(|context| context.trigger_kind == CompletionTriggerKind::INVOKED)
             .unwrap_or(false);
         let position_encoding = self.const_config().position_encoding;
-        let frames = {
-            self.document.lock().await.pages.clone()
-        };
+        let frames = { self.document.lock().await.pages.clone() };
         let completions = self
             .thread_with_world(&uri)
             .await

--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -385,7 +385,7 @@ impl LanguageServer for TypstServer {
             .map(|context| context.trigger_kind == CompletionTriggerKind::INVOKED)
             .unwrap_or(false);
         let position_encoding = self.const_config().position_encoding;
-        let frames = { self.document.lock().await.pages.clone() };
+        let doc = { self.document.lock().await.clone() };
         let completions = self
             .thread_with_world(&uri)
             .await
@@ -398,7 +398,7 @@ impl LanguageServer for TypstServer {
 
                 let typst_offset =
                     lsp_to_typst::position_to_offset(position, position_encoding, &source);
-                typst_ide::autocomplete(&world, &frames, &source, typst_offset, explicit)
+                typst_ide::autocomplete(&world, &doc.pages, &source, typst_offset, explicit)
             })
             .await
             .map(|(_, completions)| typst_to_lsp::completions(&completions).into());

--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -385,7 +385,9 @@ impl LanguageServer for TypstServer {
             .map(|context| context.trigger_kind == CompletionTriggerKind::INVOKED)
             .unwrap_or(false);
         let position_encoding = self.const_config().position_encoding;
-
+        let frames = {
+            self.document.lock().await.pages.clone()
+        };
         let completions = self
             .thread_with_world(&uri)
             .await
@@ -398,7 +400,7 @@ impl LanguageServer for TypstServer {
 
                 let typst_offset =
                     lsp_to_typst::position_to_offset(position, position_encoding, &source);
-                typst_ide::autocomplete(&world, &[], &source, typst_offset, explicit)
+                typst_ide::autocomplete(&world, &frames, &source, typst_offset, explicit)
             })
             .await
             .map(|(_, completions)| typst_to_lsp::completions(&completions).into());

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,6 +6,7 @@ use tokio::sync::{Mutex, OwnedRwLockReadGuard, RwLock, RwLockReadGuard};
 use tower_lsp::lsp_types::Url;
 use tower_lsp::Client;
 use tracing_subscriber::{reload, Registry};
+use typst::doc::Document;
 use typst::syntax::Source;
 
 use crate::config::{Config, ConstConfig};
@@ -37,6 +38,7 @@ pub mod watch;
 
 pub struct TypstServer {
     client: Client,
+    document: Arc<Mutex<Document>>,
     typst_thread: TypstThread,
     workspace: OnceCell<Arc<RwLock<Workspace>>>,
     config: Arc<RwLock<Config>>,
@@ -60,6 +62,7 @@ impl TypstServer {
             diagnostics: Mutex::new(DiagnosticsManager::new(client.clone())),
             lsp_tracing_layer_handle,
             client,
+            document: Default::default(),
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -38,7 +38,7 @@ pub mod watch;
 
 pub struct TypstServer {
     client: Client,
-    document: Arc<Mutex<Document>>,
+    document: Mutex<Arc<Document>>,
     typst_thread: TypstThread,
     workspace: OnceCell<Arc<RwLock<Workspace>>>,
     config: Arc<RwLock<Config>>,

--- a/src/server/typst_compiler.rs
+++ b/src/server/typst_compiler.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use comemo::Track;
 use tower_lsp::lsp_types::Url;
 use typst::doc::Document;
@@ -14,7 +16,7 @@ impl TypstServer {
     pub async fn compile_source(
         &self,
         uri: &Url,
-    ) -> anyhow::Result<(Option<Document>, DiagnosticsMap)> {
+    ) -> anyhow::Result<(Option<Arc<Document>>, DiagnosticsMap)> {
         let doc = self
             .scope_with_source(uri)
             .await?
@@ -30,7 +32,7 @@ impl TypstServer {
 
                         let mut diagnostics = tracer.warnings();
                         match result {
-                            Ok(document) => (Some(document), diagnostics),
+                            Ok(document) => (Some(Arc::new(document)), diagnostics),
                             Err(errors) => {
                                 diagnostics.extend_from_slice(&errors);
                                 (None, diagnostics)
@@ -43,7 +45,7 @@ impl TypstServer {
                     typst_to_lsp::diagnostics(&project, diagnostics.as_ref(), self.const_config())
                         .await;
 
-                let res: anyhow::Result<(Option<Document>, DiagnosticsMap)> =
+                let res: anyhow::Result<(Option<Arc<Document>>, DiagnosticsMap)> =
                     Ok((document, diagnostics));
                 res
             })

--- a/src/server/typst_compiler.rs
+++ b/src/server/typst_compiler.rs
@@ -15,7 +15,8 @@ impl TypstServer {
         &self,
         uri: &Url,
     ) -> anyhow::Result<(Option<Document>, DiagnosticsMap)> {
-        let doc = self.scope_with_source(uri)
+        let doc = self
+            .scope_with_source(uri)
             .await?
             .run2(|source, project| async move {
                 let (document, diagnostics) = self
@@ -42,7 +43,8 @@ impl TypstServer {
                     typst_to_lsp::diagnostics(&project, diagnostics.as_ref(), self.const_config())
                         .await;
 
-                let res: anyhow::Result<(Option<Document>, DiagnosticsMap)> = Ok((document, diagnostics));
+                let res: anyhow::Result<(Option<Document>, DiagnosticsMap)> =
+                    Ok((document, diagnostics));
                 res
             })
             .await?;


### PR DESCRIPTION
fix #157

There are mainly 3 changes:

1. Compile source to document even if no export is required.
2. Use `Arc<Document>` to avoid heavy clones
3. Add a document field to TypstServer and update it when compiling success.

![image](https://github.com/nvarner/typst-lsp/assets/25521218/7b5745f1-8271-4c1d-992e-e4c5500c21c6)
