### PR TITLE
Add configurable font paths

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -59,6 +59,15 @@
                         "Do not use semantic tokens for syntax highlighting"
                     ]
                 },
+                "typst-lsp.fontPaths": {
+                    "title": "Font Paths",
+                    "description": "Specify paths for extra folders where fonts should be searched (besides the fonts installed in your system). Each entry must be a single path to a folder.",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "title": "paths to folders containing font files"
+                    }
+                },
                 "typst-lsp.serverPath": {
                     "title": "Path to server executable",
                     "description": "The extension can use a local typst-lsp executable instead of the one bundled with the extension. This setting controls the path to the executable.",

--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -224,6 +224,22 @@ impl LanguageServer for TypstServer {
             }
         }
 
+        {
+            trace!("setting up listener to changes to font paths");
+            let workspace = self.workspace().clone();
+            config.listen_font_paths(Box::new(move |font_paths| {
+                let workspace = workspace.clone();
+                let update_fonts = move || {
+                    async move {
+                        let mut workspace = workspace.write().await;
+                        workspace.update_fonts(font_paths);
+                        Ok(())
+                    }
+                };
+                update_fonts().boxed()
+            }));
+        }
+
         trace!("setting up to watch Typst files");
         let watch_files_error = self
             .client

--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -229,12 +229,10 @@ impl LanguageServer for TypstServer {
             let workspace = self.workspace().clone();
             config.listen_font_paths(Box::new(move |font_paths| {
                 let workspace = workspace.clone();
-                let update_fonts = move || {
-                    async move {
-                        let mut workspace = workspace.write().await;
-                        workspace.update_fonts(font_paths);
-                        Ok(())
-                    }
+                let update_fonts = move || async move {
+                    let mut workspace = workspace.write().await;
+                    workspace.update_fonts(font_paths);
+                    Ok(())
                 };
                 update_fonts().boxed()
             }));

--- a/src/workspace/font_manager.rs
+++ b/src/workspace/font_manager.rs
@@ -160,6 +160,14 @@ impl Builder {
         self
     }
 
+    /// Include user-specified font paths.
+    pub fn with_font_paths(mut self, font_paths: &[PathBuf]) -> Self {
+        for font_path in font_paths {
+            self.search_dir(font_path);
+        }
+        self
+    }
+
     /// Search for fonts in the linux system font directories.
     #[cfg(all(unix, not(target_os = "macos")))]
     fn search_system(&mut self) {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -43,7 +43,7 @@ use tracing::trace;
 use typst::eval::{Bytes, Library};
 use typst::syntax::Source;
 
-use crate::config::{PositionEncoding, FontPaths};
+use crate::config::{FontPaths, PositionEncoding};
 use crate::ext::InitializeParamsExt;
 
 use self::font_manager::FontManager;

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -32,6 +32,7 @@
 //! context needed to interpret it, which is a project.
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 
 use comemo::Prehashed;
 use itertools::Itertools;
@@ -76,7 +77,7 @@ impl Workspace {
 
         Self {
             fs: FsManager::default(),
-            fonts: FontManager::builder().with_system().with_embedded().build(),
+            fonts: Self::create_font_manager(&[]),
             packages: PackageManager::new(root_paths, ExternalPackageManager::new()),
         }
     }
@@ -135,8 +136,8 @@ impl Workspace {
     }
 
     pub fn update_fonts(&mut self, font_paths: &FontPaths) {
-        // TODO
-        trace!("Updating fonts to {font_paths:?}");
+        trace!("updating font paths to {font_paths:?}");
+        self.fonts = Self::create_font_manager(font_paths);
     }
 
     pub fn open_lsp(&mut self, uri: Url, text: String) -> FsResult<()> {
@@ -185,5 +186,13 @@ impl Workspace {
         self.fs.clear();
         self.register_files()?;
         Ok(())
+    }
+
+    fn create_font_manager(font_paths: &[PathBuf]) -> FontManager {
+        FontManager::builder()
+            .with_system()
+            .with_embedded()
+            .with_font_paths(font_paths)
+            .build()
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -43,7 +43,7 @@ use tracing::trace;
 use typst::eval::{Bytes, Library};
 use typst::syntax::Source;
 
-use crate::config::PositionEncoding;
+use crate::config::{PositionEncoding, FontPaths};
 use crate::ext::InitializeParamsExt;
 
 use self::font_manager::FontManager;
@@ -132,6 +132,11 @@ impl Workspace {
 
     pub fn known_uris(&self) -> HashSet<Url> {
         self.fs.known_uris()
+    }
+
+    pub fn update_fonts(&mut self, font_paths: &FontPaths) {
+        // TODO
+        trace!("Updating fonts to {font_paths:?}");
     }
 
     pub fn open_lsp(&mut self, uri: Url, text: String) -> FsResult<()> {


### PR DESCRIPTION
Adds the equivalent of Typst CLI's `--font-path` option to the LSP. (I recommend merging #359 first if possible, as it will require a few changes to this PR when merged, but they should be very tiny changes!)

Closes https://github.com/nvarner/typst-lsp/issues/75 , related to #267

Supports:
- [X] Specifying a list of absolute paths to font folders in the configuration;
- [X] Typst recognizes the fonts in the given paths;
- [X] "Hot reload" of the font path configuration (the LSP doesn't have to be restarted when the configuration is changed);
   - The current implementation is a bit inefficient as it searches _all fonts_ again _each time_ the configuration changes. This shouldn't really be a problem, however, as I believe configuration changes aren't in the hot path. But I could add a simple check of whether the font paths have actually changed before searching for all fonts again.
- [ ] Specifying a list of relative paths to font folders in the configuration;
   - Does this actually need implementation? And what would they be relative to? The workspace root?
- [ ] Support for paths to font folders beginning with `~` to indicate the home folder;
   - Hopefully this shouldn't be too hard to implement? If it is at all desirable, that is...