### PR TITLE
Remove tab size from suggested settings.

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -98,8 +98,7 @@
         "configurationDefaults": {
             "[typst]": {
                 "editor.wordWrap": "on",
-                "editor.semanticHighlighting.enabled": true,
-                "editor.tabSize": 2
+                "editor.semanticHighlighting.enabled": true
             }
         },
         "languages": [


### PR DESCRIPTION
Introduced in https://github.com/nvarner/typst-lsp/issues/318

I don't think any extension should change the tabsize. A large reason for tabs over spaces is the freedom to change the visual size.

I guess most people prefer the same size for tabs in all languages, so there prefered size is already set.