### PR TITLE
Always use implicit autocomplete

### DIFF
--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -381,10 +381,20 @@ impl LanguageServer for TypstServer {
     ) -> jsonrpc::Result<Option<CompletionResponse>> {
         let uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
-        let explicit = params
-            .context
-            .map(|context| context.trigger_kind == CompletionTriggerKind::INVOKED)
-            .unwrap_or(false);
+
+        // FIXME: correctly identify a completion which is triggered
+        // by explicit action, such as by pressing control and space
+        // or something similar.
+        //
+        // See <https://github.com/microsoft/language-server-protocol/issues/1101>
+        // > As of LSP 3.16, CompletionTriggerKind takes the value Invoked for
+        // > both manually invoked (for ex: ctrl + space in VSCode) completions
+        // > and always on (what the spec refers to as 24/7 completions).
+        //
+        // Hence, we cannot distinguish between the two cases. Conservatively, we
+        // assume that the completion is not explicit.
+        let explicit = false;
+
         let position_encoding = self.const_config().position_encoding;
         let doc = { self.document.lock().await.clone() };
         let completions = self


### PR DESCRIPTION
fix #380. The issue is caused by we set `explicit` of `typst_ide::autocomplete` to true but it is actually not. Note that this PR doesn't provide a way to determining whether a completion request is explicit, but I still think of the change introduced by PR is an improvement.

From comment of `typst_ide::autocomplete`:
> When `explicit` is `true`, the user requested the completion by pressing control and space or something similar.

However, from <https://github.com/microsoft/language-server-protocol/issues/1101>
> As of LSP 3.16, CompletionTriggerKind takes the value Invoked for both manually invoked (for ex: ctrl + space in VSCode) completions and always on (what the spec refers to as 24/7 completions).

Hence, we cannot distinguish between the two cases (ctrl + space case or 24/7 case) in the scope of LSP. Conservatively, to fix #380, this PR assumes that the completion is not explicit instead.

---

Result 1, vscode will fallback to word suggestions in markup mode of typst:

![image](https://github.com/nvarner/typst-lsp/assets/35292584/7f17b52b-e21c-4357-821f-cb9a59a0b09c)

Result 2, we still have snippets in suitable completion scope:

![image](https://github.com/nvarner/typst-lsp/assets/35292584/8f930038-7941-4bc7-9a84-d09ca8dbc90c)



