### PR TITLE
Autocompletion for package import

### DIFF
--- a/src/workspace/package/external/remote_repo.rs
+++ b/src/workspace/package/external/remote_repo.rs
@@ -39,6 +39,13 @@ impl RepoProvider for RemoteRepoProvider {
         let downloaded = self.download_raw(url).await?;
         Ok(Box::new(downloaded))
     }
+
+    async fn retrieve_index(&self) -> RepoResult<Box<dyn AsyncBufRead + Send>> {
+        // typicially, it is https://packages.typst.org/preview/index.json
+        let url = self.index_url(PREVIEW_NAMESPACE);
+        let downloaded = self.download_raw(url).await?;
+        Ok(Box::new(downloaded))
+    }
 }
 
 impl RemoteRepoProvider {
@@ -72,6 +79,11 @@ impl RemoteRepoProvider {
 
     fn url(&self, spec: &PackageSpec) -> Url {
         let path = format!("{}/{}-{}.tar.gz", spec.namespace, spec.name, spec.version);
+        self.base_url.join(&path).expect("should be a valid URL")
+    }
+
+    fn index_url(&self, namespace: &str) -> Url {
+        let path = format!("{namespace}/index.json");
         self.base_url.join(&path).expect("should be a valid URL")
     }
 

--- a/src/workspace/package/manager.rs
+++ b/src/workspace/package/manager.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use itertools::Itertools;
 use tower_lsp::lsp_types::{Url, WorkspaceFoldersChangeEvent};
 use tracing::{error, info, trace, warn};
-use typst::diag::{FileError, PackageError as TypstPackageError};
+use typst::diag::{EcoString, FileError, PackageError as TypstPackageError};
 use typst::syntax::{FileId, PackageSpec};
 
 use crate::ext::{UriError, UrlExt};
@@ -132,6 +132,10 @@ impl PackageManager {
 
     pub fn current(&self) -> impl Iterator<Item = &Package> {
         self.current.values()
+    }
+
+    pub async fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
+        self.external.packages().await
     }
 }
 

--- a/src/workspace/project.rs
+++ b/src/workspace/project.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use comemo::Prehashed;
 use tokio::sync::OwnedRwLockReadGuard;
 use tower_lsp::lsp_types::Url;
+use typst::diag::EcoString;
 use typst::foundations::Bytes;
-use typst::syntax::{FileId, Source};
+use typst::syntax::{FileId, PackageSpec, Source};
 use typst::text::{Font, FontBook};
 use typst::Library;
 
@@ -44,6 +45,10 @@ impl Project {
 
     pub fn font(&self, id: usize) -> Option<Font> {
         self.workspace().font_manager().font(id)
+    }
+
+    pub async fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
+        self.workspace().package_manager().packages().await
     }
 
     pub fn fill_id(&self, id: FileId) -> FullFileId {

--- a/src/workspace/world/mod.rs
+++ b/src/workspace/world/mod.rs
@@ -106,7 +106,6 @@ impl World for ProjectWorld {
 
     #[tracing::instrument]
     fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
-        // TODO: implement package completion
-        &[]
+        self.block(self.project.packages())
     }
 }


### PR DESCRIPTION
Close #367 and close #383. It mainly adds `ExternalPackageManager::packages` that read the index file once from network. Then, the result will be used by typst for autocompletion.

---
Result
![~(~6{XP~@)V`MCTQ{(`@02X](https://github.com/nvarner/typst-lsp/assets/35292584/1154332c-6a69-4d77-89b0-3604c3091c30)
