### PR TITLE
Add capability to pin a main file

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -28,12 +28,16 @@
                     "enum": [
                         "never",
                         "onSave",
-                        "onType"
+                        "onPinnedMainSave",
+                        "onType",
+                        "onPinnedMainType"
                     ],
                     "enumDescriptions": [
                         "Never export PDFs, you will manually run typst.",
                         "Export PDFs when you save a file.",
-                        "Export PDFs as you type in a file."
+                        "Export PDFs when you save the pinned file.",
+                        "Export PDFs as you type in a file.",
+                        "Export PDFs as you type in the pinned file."
                     ]
                 },
                 "typst-lsp.rootPath": {
@@ -272,6 +276,16 @@
             {
                 "command": "typst-lsp.exportCurrentPdf",
                 "title": "Export the currently open file as PDF",
+                "category": "Typst"
+            },
+            {
+                "command": "typst-lsp.pinMainToCurrent",
+                "title": "Pin the main file to the currently openning document",
+                "category": "Typst"
+            },
+            {
+                "command": "typst-lsp.unpinMain",
+                "title": "Unpin the main file",
                 "category": "Typst"
             },
             {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -47,6 +47,12 @@ async function startClient(context: ExtensionContext): Promise<void> {
     context.subscriptions.push(
         commands.registerCommand("typst-lsp.exportCurrentPdf", commandExportCurrentPdf)
     );
+    context.subscriptions.push(
+        commands.registerCommand("typst-lsp.pinMainToCurrent", () => commandPinMain(true))
+    );
+    context.subscriptions.push(
+        commands.registerCommand("typst-lsp.unpinMain", () => commandPinMain(false))
+    );
     context.subscriptions.push(commands.registerCommand("typst-lsp.showPdf", commandShowPdf));
     context.subscriptions.push(commands.registerCommand("typst-lsp.clearCache", commandClearCache));
 
@@ -123,6 +129,27 @@ async function commandExportCurrentPdf(): Promise<void> {
 
     await client?.sendRequest("workspace/executeCommand", {
         command: "typst-lsp.doPdfExport",
+        arguments: [uri],
+    });
+}
+
+async function commandPinMain(isPin: boolean): Promise<void> {
+    if (!isPin) {
+        await client?.sendRequest("workspace/executeCommand", {
+            command: "typst-lsp.doPinMain",
+            arguments: ["detached"],
+        });
+    }
+
+    const activeEditor = window.activeTextEditor;
+    if (activeEditor === undefined) {
+        return;
+    }
+
+    const uri = activeEditor.document.uri.toString();
+
+    await client?.sendRequest("workspace/executeCommand", {
+        command: "typst-lsp.doPinMain",
         arguments: [uri],
     });
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,9 @@ pub enum ExportPdfMode {
     Never,
     #[default]
     OnSave,
+    OnPinnedMainSave,
     OnType,
+    OnPinnedMainType,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,9 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde_json::{Map, Value};
 use tower_lsp::lsp_types::{
-    self, ConfigurationItem, InitializeParams, PositionEncodingKind, Registration,
+    self, ConfigurationItem, InitializeParams, PositionEncodingKind, Registration, Url,
 };
+use tracing::warn;
 
 use crate::ext::InitializeParamsExt;
 
@@ -58,6 +59,7 @@ const CONFIG_ITEMS: &[&str] = &[
 
 #[derive(Default)]
 pub struct Config {
+    pub main_file: Option<Url>,
     pub export_pdf: ExportPdfMode,
     pub root_path: Option<PathBuf>,
     pub semantic_tokens: SemanticTokensMode,
@@ -150,7 +152,32 @@ impl Config {
             self.formatter = formatter;
         }
 
+        self.validate_main_file();
         Ok(())
+    }
+
+    pub async fn update_main_file(&mut self, main_file: Option<Url>) -> anyhow::Result<()> {
+        self.main_file = main_file;
+
+        self.validate_main_file();
+        Ok(())
+    }
+
+    fn validate_main_file(&mut self) {
+        if let Some(main_file) = &self.main_file {
+            if let Some(root_path) = &self.root_path {
+                if let Ok(main_file) = main_file.to_file_path() {
+                    if !main_file.starts_with(root_path) {
+                        warn!(
+                            "main file {main_file} is not in the workspace root {root_path}",
+                            main_file = main_file.display(),
+                            root_path = root_path.display(),
+                        );
+                        self.main_file = None;
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/server/command.rs
+++ b/src/server/command.rs
@@ -12,6 +12,7 @@ use super::TypstServer;
 pub enum LspCommand {
     ExportPdf,
     ClearCache,
+    PinMain,
 }
 
 impl From<LspCommand> for String {
@@ -19,6 +20,7 @@ impl From<LspCommand> for String {
         match command {
             LspCommand::ExportPdf => "typst-lsp.doPdfExport".to_string(),
             LspCommand::ClearCache => "typst-lsp.doClearCache".to_string(),
+            LspCommand::PinMain => "typst-lsp.doPinMain".to_string(),
         }
     }
 }
@@ -28,12 +30,17 @@ impl LspCommand {
         match command {
             "typst-lsp.doPdfExport" => Some(Self::ExportPdf),
             "typst-lsp.doClearCache" => Some(Self::ClearCache),
+            "typst-lsp.doPinMain" => Some(Self::PinMain),
             _ => None,
         }
     }
 
     pub fn all_as_string() -> Vec<String> {
-        vec![Self::ExportPdf.into(), Self::ClearCache.into()]
+        vec![
+            Self::ExportPdf.into(),
+            Self::ClearCache.into(),
+            Self::PinMain.into(),
+        ]
     }
 }
 
@@ -70,5 +77,34 @@ impl TypstServer {
         self.typst(|_| comemo::evict(0)).await;
 
         Ok(())
+    }
+
+    /// Pin main file to some path.
+    #[tracing::instrument(skip_all)]
+    pub async fn command_pin_main(&self, arguments: Vec<Value>) -> Result<()> {
+        if arguments.is_empty() {
+            return Err(Error::invalid_params("Missing file URI argument"));
+        }
+        let Some(file_uri) = arguments.first().and_then(|v| v.as_str()) else {
+            return Err(Error::invalid_params("Missing file URI as first argument"));
+        };
+        let file_uri = if file_uri == "detached" {
+            None
+        } else {
+            Some(
+                Url::parse(file_uri)
+                    .map_err(|_| Error::invalid_params("Parameter is not a valid URI"))?,
+            )
+        };
+
+        self.config
+            .write()
+            .await
+            .update_main_file(file_uri)
+            .await
+            .map_err(|err| {
+                error!(%err, "could not set main file");
+                jsonrpc::Error::internal_error()
+            })
     }
 }

--- a/src/server/document.rs
+++ b/src/server/document.rs
@@ -17,7 +17,10 @@ impl TypstServer {
                     self.run_diagnostics(uri).await?
                 }
             }
-            _ => self.run_diagnostics(uri).await?,
+            _ => {
+                self.run_diagnostics(self.main_url().await.as_ref().unwrap_or(uri))
+                    .await?
+            }
         }
 
         Ok(())

--- a/src/server/document.rs
+++ b/src/server/document.rs
@@ -10,6 +10,13 @@ impl TypstServer {
         let config = self.config.read().await;
         match config.export_pdf {
             ExportPdfMode::OnType => self.run_diagnostics_and_export(uri).await?,
+            ExportPdfMode::OnPinnedMainType => {
+                if let Some(main_uri) = self.main_url().await {
+                    self.run_diagnostics_and_export(&main_uri).await?
+                } else {
+                    self.run_diagnostics(uri).await?
+                }
+            }
             _ => self.run_diagnostics(uri).await?,
         }
 

--- a/src/server/hover.rs
+++ b/src/server/hover.rs
@@ -17,11 +17,12 @@ impl TypstServer {
 
         let doc = self.document.lock().await.clone();
 
+        let fid = self.workspace().read().await.full_id(uri)?;
         let result = self
-            .thread_with_world(uri)
+            .thread_with_world(self.main_url().await.as_ref().unwrap_or(uri))
             .await?
             .run(move |world| {
-                let source = world.main();
+                let source = world.source(fid.into()).ok()?;
 
                 let typst_offset =
                     lsp_to_typst::position_to_offset(position, position_encoding, &source);

--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -343,6 +343,9 @@ impl LanguageServer for TypstServer {
             Some(LspCommand::ClearCache) => {
                 self.command_clear_cache(arguments).await?;
             }
+            Some(LspCommand::PinMain) => {
+                self.command_pin_main(arguments).await?;
+            }
             None => {
                 error!("asked to execute unknown command");
                 return Err(jsonrpc::Error::method_not_found());

--- a/src/server/lsp.rs
+++ b/src/server/lsp.rs
@@ -294,11 +294,18 @@ impl LanguageServer for TypstServer {
 
         let config = self.config.read().await;
 
-        if config.export_pdf == ExportPdfMode::OnSave {
-            if let Err(err) = self.run_diagnostics_and_export(&uri).await {
-                error!(%err, %uri, "could not handle source save");
-            };
-        }
+        let uri = match config.export_pdf {
+            ExportPdfMode::OnPinnedMainSave => Some(self.main_url().await.unwrap_or(uri)),
+            ExportPdfMode::OnSave => Some(uri),
+            _ => None,
+        };
+        let Some(uri) = uri else {
+            return;
+        };
+
+        if let Err(err) = self.run_diagnostics_and_export(&uri).await {
+            error!(%err, %uri, "could not handle source save");
+        };
     }
 
     #[tracing::instrument(skip(self))]
@@ -390,15 +397,19 @@ impl LanguageServer for TypstServer {
             .unwrap_or(false);
         let position_encoding = self.const_config().position_encoding;
         let doc = { self.document.lock().await.clone() };
+        let fid = self.workspace().read().await.full_id(&uri).map_err(|err| {
+            error!(%err, %uri, "error getting completion");
+            jsonrpc::Error::internal_error()
+        })?;
         let completions = self
-            .thread_with_world(&uri)
+            .thread_with_world(self.main_url().await.as_ref().unwrap_or(&uri))
             .await
             .map_err(|err| {
                 error!(%err, %uri, "error getting completion");
                 jsonrpc::Error::internal_error()
             })?
             .run(move |world| {
-                let source = world.main();
+                let source = world.source(fid.into()).ok()?;
 
                 let typst_offset =
                     lsp_to_typst::position_to_offset(position, position_encoding, &source);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -78,6 +78,10 @@ impl TypstServer {
             .expect("workspace should be initialized")
     }
 
+    pub async fn main_url(&self) -> Option<Url> {
+        self.config.read().await.main_file.clone()
+    }
+
     pub fn typst_global_scopes(&self) -> typst::foundations::Scopes {
         typst::foundations::Scopes::new(Some(&TYPST_STDLIB))
     }


### PR DESCRIPTION
This PR proposes an abstraction corresponding to "Preview this file" in official webapp. In conclusion, this PR adds a "typst-lsp.doPinMain" command to lsp program which could then get used by:
+ user manually runs command "typst-lsp.pinMainToCurrent" or "typst-lsp.unpinMain" in VSCode.
+ user writes some lua script to automate the pin action.
+ some other vscode extension (such as typst-preview) pins a previewing file automatically.

![image](https://github.com/nvarner/typst-lsp/assets/35292584/f2358478-74d6-40b3-85ae-d161d7c2ef81)

---

Usage 1: improve mode of exportPDF by adding "onPinnedMain{Save,Type}".
Currently, automatically exportPDF on save or on type is annoying since typst-lsp cannot identify the source files that has empty content. This PR can allow users only exporting PDF "onPinnedMain{Save,Type}", close #11, may close #184, may close #285.

![image](https://github.com/nvarner/typst-lsp/assets/35292584/b3c93a5d-9178-490f-86bc-ce5ef94b327f)

---
Usage 2: make hover tip and autocompletion according to the pinned file.

Before, hover variable in template.typ doesn't work at all:

![image](https://github.com/nvarner/typst-lsp/assets/35292584/0339e33f-3aac-4f8d-a68e-0943ed62277a)

After, it shows result correctly:

![image](https://github.com/nvarner/typst-lsp/assets/35292584/0b54056f-1b65-40aa-a024-1694d29a09e3)

---

Usage 3: show diagnostics according to compilation of the pinned file when editing other files, close #153.

Before, the errors in thesis.typ fly away if the user doesn't focus thesis.typ:

![image](https://github.com/nvarner/typst-lsp/assets/35292584/1e1e789f-6e5b-4c89-b4d8-445145e2871f)

After, lsp will show diagnostics according to compilation of the pinned file when editing template.typ:

![image](https://github.com/nvarner/typst-lsp/assets/35292584/4f3674a3-c4e1-400a-9c25-60ccbf19fe9c)

---

Usage 3.5: eliminate false errors in a project with multiple files.

Note that lsp may also produces false errors, such as errors on bib things. Once this PR is ready, editors could pin the main file in a project with multiple files, may close https://github.com/nvarner/typst-lsp/issues/64, may close https://github.com/nvarner/typst-lsp/issues/366.

