### PR TITLE
Fixed typo + improved language consistency in VS Code command titles

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -275,7 +275,7 @@
         "commands": [
             {
                 "command": "typst-lsp.exportCurrentPdf",
-                "title": "Export the currently open file as PDF",
+                "title": "Export the currently opened file as PDF",
                 "category": "Typst"
             },
             {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -280,7 +280,7 @@
             },
             {
                 "command": "typst-lsp.pinMainToCurrent",
-                "title": "Pin the main file to the currently openning document",
+                "title": "Pin the main file to the currently opened document",
                 "category": "Typst"
             },
             {


### PR DESCRIPTION
This fixes a typo in the VSCode command actions (`openning` -> `opened`) and slightly rewords another action (`open` -> `opened`) to be more consistent with the others.