### PR TITLE
add config example for `coc.nvim` users

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ Run `CocConfig` to edit the settings so that `coc.nvim` could offer functions su
 "languageserver": {
     "typst": {
         "command": "typst-lsp",
-        "filetypes": ["typst"]
+        "filetypes": ["typst"],
+        "settings": {"exportPdf": "onType"}
         }
     }
 }


### PR DESCRIPTION
I am not the first one who need to configure `typst-lsp` in coc, @ysl2 has already been trying as in #422, but that issue was closed without a resolution. Today I finally figure it out and hope this saves time for other coc users.